### PR TITLE
1987: Changes for non-authenticated user payment

### DIFF
--- a/openshift/templates/api-config.json
+++ b/openshift/templates/api-config.json
@@ -51,7 +51,8 @@
         "NATS_SUBJECT": "entity.filing.payment",
         "NATS_QUEUE": "filing-worker",
         "BCOL_PAYMENTS_WSDL_URL": "${BCOL_PAYMENTS_WSDL_URL}",
-        "BCOL_API_ENDPOINT": "https://${BCOL_API_NAME}-${TAG_NAME}.pathfinder.gov.bc.ca/api/v1/reports"
+        "BCOL_API_ENDPOINT": "https://${BCOL_API_NAME}-${TAG_NAME}.pathfinder.gov.bc.ca/api/v1/reports",
+        "VALID_REDIRECT_URLS": "https://${AUTH_WEB_NAME}-${TAG_NAME}.pathfinder.gov.bc.ca/cooperatives/*"
       }
     }
   ],

--- a/pay-api/config.py
+++ b/pay-api/config.py
@@ -53,7 +53,7 @@ def _get_config(config_key: str, **kwargs):
         value = os.getenv(config_key, kwargs.get('default'))
     else:
         value = os.getenv(config_key)
-        assert value
+        # assert value TODO Un-comment once we find a solution to run pre-hook without initializing app
     return value
 
 
@@ -117,6 +117,9 @@ class _Config(object):  # pylint: disable=too-few-public-methods
 
     # BCOL Service
     BCOL_API_ENDPOINT = _get_config('BCOL_API_ENDPOINT')
+
+    # Valid Payment redirect URLs
+    VALID_REDIRECT_URLS = [(val.strip() if val != '' else None) for val in _get_config('VALID_REDIRECT_URLS', default='').split(',')]
 
     TESTING = False
     DEBUG = True
@@ -234,6 +237,8 @@ class TestConfig(_Config):  # pylint: disable=too-few-public-methods
     NATS_SUBJECT = 'entity.filing.test'
 
     BCOL_API_ENDPOINT = 'https://mock-lear-tools.pathfinder.gov.bc.ca/rest/bcol-api-1.0.0.yaml/1.0'
+
+    VALID_REDIRECT_URLS = ['http://localhost:8080/*']
 
 
 class ProdConfig(_Config):  # pylint: disable=too-few-public-methods

--- a/pay-api/src/pay_api/__init__.py
+++ b/pay-api/src/pay_api/__init__.py
@@ -18,12 +18,11 @@ This module is the API for the Legal Entity system.
 
 import os
 
+import sentry_sdk
 from flask import Flask
 from sbc_common_components.exception_handling.exception_handler import ExceptionHandler
 from sbc_common_components.utils.camel_case_response import convert_to_camel
-from sentry_sdk.integrations.flask import FlaskIntegration  # noqa: I001
-
-import sentry_sdk  # noqa: I001; pylint: disable=ungrouped-imports; conflicts with Flake8
+from sentry_sdk.integrations.flask import FlaskIntegration
 
 import config
 from config import _Config
@@ -33,7 +32,6 @@ from pay_api.utils.logging import setup_logging
 from pay_api.utils.run_version import get_run_version
 
 
-# important to do this first
 setup_logging(os.path.join(_Config.PROJECT_ROOT, 'logging.conf'))
 
 

--- a/pay-api/src/pay_api/factory/payment_system_factory.py
+++ b/pay-api/src/pay_api/factory/payment_system_factory.py
@@ -20,9 +20,9 @@ from flask import current_app
 from pay_api.exceptions import BusinessException
 from pay_api.services.base_payment_system import PaymentSystemService
 from pay_api.services.internal_pay_service import InternalPayService
-from pay_api.services.bcol_service import BcolService
+from pay_api.services.bcol_service import BcolService  # noqa: I001
 from pay_api.services.paybc_service import PaybcService
-from pay_api.utils.enums import Role, PaymentSystem
+from pay_api.utils.enums import Role, PaymentSystem  # noqa: I001
 from pay_api.utils.errors import Error
 
 

--- a/pay-api/src/pay_api/models/__init__.py
+++ b/pay-api/src/pay_api/models/__init__.py
@@ -22,7 +22,7 @@ from .db import db, ma
 from .fee_code import FeeCode, FeeCodeSchema
 from .fee_schedule import FeeSchedule, FeeScheduleSchema
 from .filing_type import FilingType, FilingTypeSchema
-from .payment_account import PaymentAccount, PaymentAccountSchema
+from .payment_account import PaymentAccount, PaymentAccountSchema  # noqa: I001
 from .invoice import Invoice, InvoiceSchema
 from .invoice_reference import InvoiceReference, InvoiceReferenceSchema
 from .payment import Payment, PaymentSchema

--- a/pay-api/src/pay_api/services/payment_service.py
+++ b/pay-api/src/pay_api/services/payment_service.py
@@ -364,9 +364,8 @@ def _complete_post_payment(pay_service: PaymentSystemService, payment: Payment):
                                                                     {
                                                                         'clientSystemUrl': '',
                                                                         'payReturnUrl': ''
-                                                                    },
-                                                                    skip_auth_check=True)
-        transaction.update_transaction(payment.id, transaction.id, receipt_number=None, skip_auth_check=True)
+                                                                    })
+        transaction.update_transaction(payment.id, transaction.id, receipt_number=None)
 
 
 def _update_active_transactions(payment_id):
@@ -375,7 +374,7 @@ def _update_active_transactions(payment_id):
     current_app.logger.debug(transaction)
     if transaction:
         # check existing payment status in PayBC;
-        PaymentTransaction.update_transaction(payment_id, transaction.id, None, skip_auth_check=True)
+        PaymentTransaction.update_transaction(payment_id, transaction.id, None)
 
 
 def _check_if_payment_is_completed(payment):

--- a/pay-api/src/pay_api/services/queue_publisher.py
+++ b/pay-api/src/pay_api/services/queue_publisher.py
@@ -18,11 +18,10 @@ import json
 import random
 
 from flask import current_app
-
 from nats.aio.client import Client as NATS  # noqa N814; by convention the name is NATS
 from stan.aio.client import Client as STAN  # noqa N814; by convention the name is STAN
 
-from pay_api.utils.handlers import closed_cb, error_cb
+from pay_api.utils.handlers import closed_cb, error_cb  # noq I001; conflict with flake8
 
 
 def publish_response(payload):

--- a/pay-api/src/pay_api/utils/enums.py
+++ b/pay-api/src/pay_api/utils/enums.py
@@ -62,3 +62,4 @@ class Role(Enum):
     STAFF = 'staff'
     VIEWER = 'view'
     EDITOR = 'edit'
+    SYSTEM = 'system'

--- a/pay-api/src/pay_api/utils/errors.py
+++ b/pay-api/src/pay_api/utils/errors.py
@@ -31,6 +31,8 @@ class Error(Enum):
     PAY010 = 'Payment is already completed', HTTPStatus.BAD_REQUEST
     PAY011 = 'Payment is already cancelled', HTTPStatus.BAD_REQUEST
     PAY012 = 'Invalid invoice identifier', HTTPStatus.BAD_REQUEST
+    PAY013 = 'Invalid redirect url', HTTPStatus.UNAUTHORIZED
+
     PAY020 = 'Invalid Account Number for the User', HTTPStatus.BAD_REQUEST
     PAY021 = 'Zero dollars deducted from BCOL', HTTPStatus.BAD_REQUEST
 

--- a/pay-api/src/pay_api/utils/util.py
+++ b/pay-api/src/pay_api/utils/util.py
@@ -16,6 +16,7 @@
 
 A simple decorator to add the options method to a Request Class.
 """
+from flask import current_app
 
 
 def cors_preflight(methods: str = 'GET'):
@@ -31,3 +32,14 @@ def cors_preflight(methods: str = 'GET'):
         return f
 
     return wrapper
+
+
+def is_valid_redirect_url(url: str):
+    """Validate if the url is valid based on the VALID Redirect Url."""
+    valid_urls: list = current_app.config.get('VALID_REDIRECT_URLS')
+    is_valid = False
+    for valid_url in valid_urls:
+        is_valid = url.startswith(valid_url[:-1]) if valid_url.endswith('*') else valid_url == url
+        if is_valid:
+            break
+    return is_valid

--- a/pay-api/tests/unit/api/test_receipt.py
+++ b/pay-api/tests/unit/api/test_receipt.py
@@ -20,6 +20,7 @@ Test-Suite to ensure that the /receipt endpoint is working as expected.
 import json
 
 import pytest
+
 from tests.utilities.base_test import get_claims, get_payment_request, get_zero_dollar_payment_request, token_header
 
 
@@ -51,8 +52,8 @@ def test_receipt_creation(session, client, jwt, app):
     rv = client.post(f'/api/v1/payment-requests/{payment_id}/transactions', data=json.dumps(data),
                      headers=headers)
     txn_id = rv.json.get('id')
-    rv = client.patch(f'/api/v1/payment-requests/{payment_id}/transactions/{txn_id}?receipt_number={receipt_number}',
-                      data=None, headers=headers)
+    rv = client.patch(f'/api/v1/payment-requests/{payment_id}/transactions/{txn_id}',
+                      data=json.dumps({'receipt_number': receipt_number}), headers=headers)
 
     filing_data = {
         'corpName': 'CP0001234',
@@ -80,8 +81,8 @@ def test_receipt_creation_with_invoice(session, client, jwt, app):
     rv = client.post(f'/api/v1/payment-requests/{payment_id}/transactions', data=json.dumps(data),
                      headers=headers)
     txn_id = rv.json.get('id')
-    client.patch(f'/api/v1/payment-requests/{payment_id}/transactions/{txn_id}?receipt_number={receipt_number}',
-                 data=None, headers=headers)
+    client.patch(f'/api/v1/payment-requests/{payment_id}/transactions/{txn_id}',
+                 data=json.dumps({'receipt_number': receipt_number}), headers=headers)
     filing_data = {
         'corpName': 'CP0001234',
         'filingDateTime': 'June 27, 2019',
@@ -106,8 +107,8 @@ def test_receipt_creation_with_invalid_request(session, client, jwt, app):
     rv = client.post(f'/api/v1/payment-requests/{payment_id}/transactions?redirect_uri={redirect_uri}', data=None,
                      headers=headers)
     txn_id = rv.json.get('id')
-    client.patch(f'/api/v1/payment-requests/{payment_id}/transactions/{txn_id}?receipt_number={receipt_number}',
-                 data=None, headers=headers)
+    client.patch(f'/api/v1/payment-requests/{payment_id}/transactions/{txn_id}',
+                 data=json.dumps({'receipt_number': receipt_number}), headers=headers)
     filing_data = {
         'corpName': 'CP0001234'
     }

--- a/pay-api/tests/unit/conf/test_version.py
+++ b/pay-api/tests/unit/conf/test_version.py
@@ -16,10 +16,9 @@
 
 Test-Suite to ensure that the version utilities are working as expected.
 """
-from tests import skip_in_pod
-
 from pay_api import utils
 from pay_api.version import __version__
+from tests import skip_in_pod
 
 
 @skip_in_pod

--- a/pay-api/tests/unit/factory/test_payment_system_factory.py
+++ b/pay-api/tests/unit/factory/test_payment_system_factory.py
@@ -20,15 +20,16 @@ Test-Suite to ensure that the CorpType Class is working as expected.
 import pytest
 
 from pay_api.services.base_payment_system import PaymentSystemService
-from pay_api.services.paybc_service import PaybcService
 from pay_api.services.internal_pay_service import InternalPayService
-from pay_api.factory.payment_system_factory import PaymentSystemFactory
+from pay_api.services.paybc_service import PaybcService
+from pay_api.utils.enums import PaymentSystem, Role
 from pay_api.utils.errors import Error
-from pay_api.utils.enums import Role, PaymentSystem
 
 
 def test_paybc_system_factory(session):
     """Assert a paybc service is returned."""
+    from pay_api.factory.payment_system_factory import PaymentSystemFactory  # noqa I001; errors out the test case
+
     # Test for CC and CP
     instance = PaymentSystemFactory.create(payment_method='CC', corp_type='CP')
     assert isinstance(instance, PaybcService)
@@ -58,6 +59,8 @@ def test_paybc_system_factory(session):
 
 def test_invalid_pay_system(session):
     """Test invalid data."""
+    from pay_api.factory.payment_system_factory import PaymentSystemFactory  # noqa I001; errors out the test case
+
     from pay_api.exceptions import BusinessException
 
     with pytest.raises(BusinessException) as excinfo:
@@ -77,4 +80,3 @@ def test_invalid_pay_system(session):
     assert excinfo.value.status == Error.PAY003.status
     assert excinfo.value.message == Error.PAY003.message
     assert excinfo.value.code == Error.PAY003.name
-

--- a/pay-api/tests/unit/services/test_auth.py
+++ b/pay-api/tests/unit/services/test_auth.py
@@ -22,20 +22,60 @@ from werkzeug.exceptions import HTTPException
 
 from pay_api.services.auth import check_auth
 from pay_api.utils.constants import EDIT_ROLE, VIEW_ROLE
+from pay_api.utils.enums import Role
+from tests.utilities.base_test import get_claims, token_header
 
 
-def test_auth_for_roles(session):
+def test_auth_role_for_service_account(app, jwt, monkeypatch):
+    """Assert the auth works for service account."""
+    def mock_auth(fake1, fake2):  # pylint: disable=unused-argument; mocks of library methods
+        token = jwt.create_jwt(get_claims(roles=[Role.SYSTEM.value, Role.EDITOR.value]), token_header)
+        headers = {'Authorization': 'Bearer ' + token}
+        return headers['Authorization']
+
+    with app.test_request_context():
+        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        # Test one of roles
+        check_auth('CP0001234', jwt=jwt, one_of_roles=[EDIT_ROLE])
+
+
+def test_auth_role_for_service_account_with_no_edit_role(app, jwt, monkeypatch):
+    """Assert the auth works for service account."""
+    def mock_auth(fake1, fake2):  # pylint: disable=unused-argument; mocks of library methods
+        token = jwt.create_jwt(get_claims(roles=[Role.SYSTEM.value], role=''), token_header)
+        headers = {'Authorization': 'Bearer ' + token}
+        return headers['Authorization']
+
+    with app.test_request_context():
+        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        with pytest.raises(HTTPException) as excinfo:
+            # Test one of roles
+            check_auth('CP0001234', jwt=jwt, one_of_roles=[EDIT_ROLE])
+            assert excinfo.exception.code == 403
+
+
+def test_auth_for_client_user_roles(app, jwt, monkeypatch):
     """Assert that the auth is working as expected."""
-    # Test one of roles
-    check_auth('CP0001234', None, one_of_roles=[EDIT_ROLE])
-    # Test contains roles
-    check_auth('CP0001234', None, contains_role=EDIT_ROLE)
+    token = jwt.create_jwt(get_claims(roles=[Role.EDITOR.value]), token_header)
 
-    # Test for exception
-    with pytest.raises(HTTPException) as excinfo:
-        check_auth('CP0000000', None, contains_role=VIEW_ROLE)
-        assert excinfo.exception.code == 403
+    headers = {'Authorization': 'Bearer ' + token}
 
-    with pytest.raises(HTTPException) as excinfo:
-        check_auth('CP0000000', None, one_of_roles=[EDIT_ROLE])
-        assert excinfo.exception.code == 403
+    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
+        return headers['Authorization']
+
+    with app.test_request_context():
+        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+
+        # Test one of roles
+        check_auth('CP0001234', jwt=jwt, one_of_roles=[EDIT_ROLE])
+        # Test contains roles
+        check_auth('CP0001234', jwt=jwt, contains_role=EDIT_ROLE)
+
+        # Test for exception
+        with pytest.raises(HTTPException) as excinfo:
+            check_auth('CP0000000', jwt=jwt, contains_role=VIEW_ROLE)
+            assert excinfo.exception.code == 403
+
+        with pytest.raises(HTTPException) as excinfo:
+            check_auth('CP0000000', jwt=jwt, one_of_roles=[EDIT_ROLE])
+            assert excinfo.exception.code == 403

--- a/pay-api/tests/unit/services/test_bcol_service.py
+++ b/pay-api/tests/unit/services/test_bcol_service.py
@@ -19,8 +19,9 @@ Test-Suite to ensure that the BCOL Service layer is working as expected.
 
 from pay_api.models.fee_schedule import FeeSchedule
 from pay_api.services.bcol_service import BcolService
-from tests.utilities.base_test import factory_payment_account, factory_payment_line_item, factory_payment, \
-    factory_invoice, factory_invoice_reference
+from tests.utilities.base_test import (
+    factory_invoice, factory_invoice_reference, factory_payment, factory_payment_account, factory_payment_line_item)
+
 
 bcol_service = BcolService()
 

--- a/pay-api/tests/unit/services/test_invoice_reference.py
+++ b/pay-api/tests/unit/services/test_invoice_reference.py
@@ -17,12 +17,9 @@
 Test-Suite to ensure that the Invoice Reference Service is working as expected.
 """
 
-import pytest
-from tests.utilities.base_test import factory_invoice, factory_payment, factory_payment_account
-
-from pay_api.exceptions import BusinessException
 from pay_api.services.invoice_reference import InvoiceReference
 from pay_api.utils.enums import Status
+from tests.utilities.base_test import factory_invoice, factory_payment, factory_payment_account
 
 
 def test_invoice_saved_from_new(session):

--- a/pay-api/tests/unit/services/test_payment_service.py
+++ b/pay-api/tests/unit/services/test_payment_service.py
@@ -30,6 +30,7 @@ from tests.utilities.base_test import (
     factory_invoice, factory_invoice_reference, factory_payment, factory_payment_account, factory_payment_line_item,
     factory_payment_transaction, get_payment_request, get_zero_dollar_payment_request)
 
+
 test_user_token = {'preferred_username': 'test'}
 
 

--- a/pay-api/tests/unit/services/test_receipt.py
+++ b/pay-api/tests/unit/services/test_receipt.py
@@ -22,8 +22,7 @@ from datetime import datetime
 import pytest
 
 from pay_api.exceptions import BusinessException
-from pay_api.models import (
-    FeeSchedule)
+from pay_api.models import FeeSchedule
 from pay_api.services.payment_service import PaymentService
 from pay_api.services.receipt import Receipt as ReceiptService
 from tests.utilities.base_test import (

--- a/pay-api/tests/utilities/base_test.py
+++ b/pay-api/tests/utilities/base_test.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from pay_api.models import Invoice, InvoiceReference, Payment, PaymentAccount, PaymentLineItem, PaymentTransaction
 from pay_api.utils.enums import Role, Status
 
+
 token_header = {
     'alg': 'RS256',
     'typ': 'JWT',
@@ -29,7 +30,8 @@ token_header = {
 }
 
 
-def get_claims(app_request=None, role: str = Role.EDITOR.value, username: str = 'CP0001234', login_source: str = None):
+def get_claims(app_request=None, role: str = Role.EDITOR.value, username: str = 'CP0001234', login_source: str = None,
+               roles: list = []):
     """Return the claim with the role param."""
     claim = {
         'jti': 'a50fafa4-c4d6-4a9b-9e51-1e5e0d102878',
@@ -44,7 +46,8 @@ def get_claims(app_request=None, role: str = Role.EDITOR.value, username: str = 
             {
                 'roles':
                     [
-                        '{}'.format(role)
+                        '{}'.format(role),
+                        *roles
                     ]
             },
         'preferred_username': username,
@@ -193,3 +196,11 @@ def factory_invoice_reference(invoice_id: int, invoice_number: str = '10021'):
     return InvoiceReference(invoice_id=invoice_id,
                             status_code='CREATED',
                             invoice_number=invoice_number)
+
+
+def get_paybc_transaction_request():
+    """Return a stub payment transaction request."""
+    return {
+        'clientSystemUrl': 'http://localhost:8080/abcd',
+        'payReturnUrl': 'http://localhost:8081/xyz'
+    }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/1987

*Description of changes:*
- Changes to support service account API calls
- Changes to make transactions endpoints open and adding redirect url validation
- Fixed existing flake8 errors
- Changed transactions patch to receive json instead of url param

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [x] No test case failures and proper coverage for all modules/classes
- [x] Updated the deployment configs for new environment variable(s)
- [ ] Updated the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
