### PR TITLE
1872: Changes to get sites if site creation fails

### DIFF
--- a/pay-api/src/pay_api/services/oauth_service.py
+++ b/pay-api/src/pay_api/services/oauth_service.py
@@ -63,11 +63,16 @@ class OAuthService:
                 raise ServiceUnavailableException(exc)
             raise exc
         finally:
-            current_app.logger.debug(response.headers if response else 'Empty Response Headers')
-            current_app.logger.info('response : {}'.format(response.text if response else ''))
+            OAuthService.__log_response(response)
 
         current_app.logger.debug('>post')
         return response
+
+    @staticmethod
+    def __log_response(response):
+        if response is not None:
+            current_app.logger.debug(response.headers)
+            current_app.logger.info('response : {}'.format(response.text if response else ''))
 
     @staticmethod
     def get(endpoint, token, auth_header_type: AuthHeaderType, content_type: ContentType,
@@ -100,8 +105,7 @@ class OAuthService:
                 raise ServiceUnavailableException(exc)
             raise exc
         finally:
-            current_app.logger.debug(response.headers if response else 'Empty Response Headers')
-            current_app.logger.info('response : {}'.format(response.text if response else ''))
+            OAuthService.__log_response(response)
 
         current_app.logger.debug('>GET')
         return response


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/1872

*Description of changes:*
- If site creation throws 400 get sites[0] to use as the current site

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [x] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updated the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
