### PR TITLE
Removing space from transaction number to avoid PayBC error

### DIFF
--- a/pay-api/src/pay_api/services/paybc_service.py
+++ b/pay-api/src/pay_api/services/paybc_service.py
@@ -81,7 +81,7 @@ class PaybcService(PaymentSystemService, OAuthService):
         transaction_num_suffix = secrets.token_hex(10) \
             if current_app.config.get('GENERATE_RANDOM_INVOICE_NUMBER', 'False').lower() == 'true' \
             else payment_account.corp_number
-        transaction_number = f'{invoice_id}-{transaction_num_suffix}'
+        transaction_number = f'{invoice_id}-{transaction_num_suffix}'.replace(' ', '')
 
         invoice = dict(
             batch_source=PAYBC_BATCH_SOURCE,


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
Removing space from transaction number to avoid PayBC error

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updated the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
