### PR TITLE
Adding pdf template and download for transaction reports

### DIFF
--- a/pay-api/src/pay_api/services/payment.py
+++ b/pay-api/src/pay_api/services/payment.py
@@ -224,10 +224,11 @@ class Payment:  # pylint: disable=too-many-instance-attributes
 
         report_payload = {
             'reportName': report_name,
-            'data': {
+            'templateVars': {
                 'columns': labels,
                 'values': []
-            }
+            },
+            'populatePageNumber': 'true'
         }
 
         for item in results.get('items'):
@@ -253,7 +254,7 @@ class Payment:  # pylint: disable=too-many-instance-attributes
                 item.get('status_code'),
                 invoice.get('business_identifier')
             ]
-            report_payload['data']['values'].append(row_value)
+            report_payload['templateVars']['values'].append(row_value)
 
         report_response = OAuthService.post(endpoint=current_app.config.get('REPORT_API_BASE_URL'),
                                             token=kwargs['user'].bearer_token,

--- a/pay-api/src/pay_api/services/payment.py
+++ b/pay-api/src/pay_api/services/payment.py
@@ -227,8 +227,7 @@ class Payment:  # pylint: disable=too-many-instance-attributes
             'templateVars': {
                 'columns': labels,
                 'values': []
-            },
-            'populatePageNumber': 'true'
+            }
         }
 
         for item in results.get('items'):

--- a/report-api/report-templates/payment_transactions.html
+++ b/report-api/report-templates/payment_transactions.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+
+<head lang="en">
+    <meta charset="UTF-8">
+    <style>
+   
+    body {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 16px;
+    }
+
+    table {
+      border-collapse: collapse;
+    }
+
+    td {
+      vertical-align: top
+    }
+
+    hr {
+      height: 1px;
+      border: none;
+      background-color: #fcba19;
+    }
+
+    .main-table {
+      width: 100%;
+    }
+
+    .wordmark {
+      font-family: Georgia, 'Times New Roman', Times, serif;
+    }
+
+    .bcgov-header-row {
+      padding: 6px 20px
+    }
+
+    .bcgov-footer-row td {
+      padding: 8px 20px;
+      font-size: 14px;
+    }
+
+    .bcgov-blue-bg {
+      color: #ffffff;
+      background-color: #003366;
+    }
+
+    .align-left {
+      text-align: left;
+    }
+
+    .no-padding {
+      padding: 0 !important;
+    }
+
+    .fixed-cell {
+      width: 1%;
+      word-wrap: break-word;
+      border: 1px solid #003366;
+      font-size: 12px;
+    }
+
+
+    </style>
+</head>
+
+<body>
+<table class="main-table" align="left">
+    <thead class="bcgov-header-row bcgov-blue-bg">
+    <tr>
+        {% for column in columns %}
+        <th class="fixed-cell">{{ column }}</th>
+        {% endfor %}
+    </tr>
+    </thead>
+    <tbody>
+    {% for row in values %}
+    <tr>
+        {% for value in row %}
+        <td class="fixed-cell">{{ value }}</td>
+        {% endfor %}
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+</table>
+</body>
+
+</html>

--- a/report-api/src/api/resources/report.py
+++ b/report-api/src/api/resources/report.py
@@ -43,7 +43,7 @@ class Report(Resource):
         response_content_type = request.headers.get('Accept', 'application/pdf')
         if response_content_type == 'text/csv':
             file_name = '{}.csv'.format(request_json.get('reportName'))
-            report = CsvService.create_report(request_json.get('data'))
+            report = CsvService.create_report(request_json.get('templateVars'))
         else:
             file_name = '{}.pdf'.format(request_json.get('reportName'))
             template_vars = request_json['templateVars']

--- a/report-api/tests/unit/api/test_reports.py
+++ b/report-api/tests/unit/api/test_reports.py
@@ -36,7 +36,6 @@ def test_generate_report_with_existing_template(client, jwt, app):
     headers = {'Authorization': f'Bearer {token}', 'content-type': 'application/json'}
 
     rv = client.get('/api/v1/templates')
-    print(rv.json)
     template_name = rv.json['report-templates'][0]
     assert template_name is not None
     request_url = '/api/v1/reports'.format(template_name)
@@ -136,7 +135,7 @@ def test_csv_report(client, jwt, app):
     request_url = '/api/v1/reports'
     request_data = {
         'reportName': 'test',
-        'data': {
+        'templateVars': {
             'columns': [
                 'a',
                 'b',
@@ -171,7 +170,7 @@ def test_csv_report_with_invalid_request(client, jwt, app):
     request_url = '/api/v1/reports'
     request_data = {
         'reportName': 'test',
-        'data': {
+        'templateVars': {
 
         }
     }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/3286

*Description of changes:*
- Adding pdf template and changes in pay-api to download pdf report

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updated the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
