### PR TITLE
Handling return from direct pay to auth

### DIFF
--- a/docs/docs/PayBC Mocking/paybc-1.0.0.yaml
+++ b/docs/docs/PayBC Mocking/paybc-1.0.0.yaml
@@ -4,6 +4,86 @@ info:
   description: PayBC API reference documentation
   version: 1.0.0
 paths:
+  '/paybc/payment/{paybc_ref_number}/{transaction_number}':
+    get:
+      tags:
+        - PayBC get transaction
+      summary: ayBC get transaction
+      description: ayBC get transaction.
+      operationId: PAYBC_GET_TXN
+      parameters:
+        - name: paybc_ref_number
+          in: path
+          description: PayBC Ref Number.
+          required: true
+          schema:
+            type: string
+        - name: transaction_number
+          in: path
+          description: Transaction Number.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cont'
+              examples:
+                '1234567890':
+                  value:
+                    pbcRefNumber: '10006'
+                    trnNumber: EZ000101
+                    trnDate: '2020-04-18'
+                    description: Direct Sale
+                    trnAmount: '100.00'
+                    paymentMethod: CC
+                    currency: CAD
+                    glDate: '2020-04-18'
+                    paymentStatus: PNDNG/PAID/CMPLT
+                    trnOrderId: " 45678"
+                    paymentAuthCode: " 04066N"
+                    cardType: " VI"
+                    revenue:
+                    - lineNumber: " 1"
+                      revenueAccount: 039.18ACE.14691.8928.1800000.000000.0000
+                      revenueAmount: '75.00'
+                      glStatus: 'NEW/IN PROCESS/REJECT/PROCESSED '
+                      glErrorMessage: Invalid revenue account
+                    - lineNumber: " 2"
+                      revenueAccount: 039.18ACE.14692.8928.1800000.000000.0000
+                      revenueAmount: '25.00'
+                      glStatus: 'NEW/IN PROCESS/REJECT/PROCESSED '
+                      glErrorMessage: Invalid revenue account
+
+        '400':
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    parameters:
+      - name: paybc_ref_number
+        in: path
+        required: true
+        schema:
+          format: string
+          type: string
+        examples:
+          '1234567890':
+            value: 10006
+      - name: tranasction_number
+        in: path
+        required: true
+        schema:
+          format: string
+          type: string
+        examples:
+          '1234567890':
+            value: 1234567890
+
   '/cfs/parties/{party_number}/accs/{account_number}/sites/{site_number}/conts/{contact_number}':
     put:
       tags:

--- a/docs/docs/PayBC Mocking/paybc-1.0.0.yaml
+++ b/docs/docs/PayBC Mocking/paybc-1.0.0.yaml
@@ -34,29 +34,29 @@ paths:
               examples:
                 '1234567890':
                   value:
-                    pbcRefNumber: '10006'
-                    trnNumber: EZ000101
-                    trnDate: '2020-04-18'
-                    description: Direct Sale
-                    trnAmount: '100.00'
-                    paymentMethod: CC
-                    currency: CAD
-                    glDate: '2020-04-18'
-                    paymentStatus: PNDNG/PAID/CMPLT
-                    trnOrderId: " 45678"
-                    paymentAuthCode: " 04066N"
-                    cardType: " VI"
-                    revenue:
-                    - lineNumber: " 1"
-                      revenueAccount: 039.18ACE.14691.8928.1800000.000000.0000
-                      revenueAmount: '75.00'
-                      glStatus: 'NEW/IN PROCESS/REJECT/PROCESSED '
-                      glErrorMessage: Invalid revenue account
-                    - lineNumber: " 2"
-                      revenueAccount: 039.18ACE.14692.8928.1800000.000000.0000
-                      revenueAmount: '25.00'
-                      glStatus: 'NEW/IN PROCESS/REJECT/PROCESSED '
-                      glErrorMessage: Invalid revenue account
+                      pbcrefnumber: '10007'
+                      trnnumber: '1'
+                      trndate: '2020-08-10'
+                      description: Direct_Sale
+                      trnamount: '50.0'
+                      paymentmethod: CC
+                      currency: CAD
+                      gldate: '2020-08-10'
+                      paymentstatus: PAID
+                      trnorderid: '1003558'
+                      paymentauthcode: TEST
+                      cardtype: VI
+                      revenue:
+                      - linenumber: '1'
+                        revenueaccount: 112.32562.20245.4378.3212319.000000.0000
+                        revenueamount: '20'
+                        glstatus: PAID
+                        glerrormessage: 
+                      - linenumber: '2'
+                        revenueaccount: 112.32562.20245.4378.3212319.000000.0000
+                        revenueamount: '30'
+                        glstatus: PAID
+                        glerrormessage: 
 
         '400':
           description: BadRequest

--- a/docs/docs/PayBC Mocking/paybc-1.0.0.yaml
+++ b/docs/docs/PayBC Mocking/paybc-1.0.0.yaml
@@ -74,7 +74,7 @@ paths:
         examples:
           '1234567890':
             value: 10006
-      - name: tranasction_number
+      - name: transaction_number
         in: path
         required: true
         schema:

--- a/pay-api/config.py
+++ b/pay-api/config.py
@@ -101,7 +101,7 @@ class _Config(object):  # pylint: disable=too-few-public-methods
     PAYBC_DIRECT_PAY_REF_NUMBER = _get_config('PAYBC_DIRECT_PAY_REF_NUMBER')
     PAYBC_DIRECT_PAY_API_KEY = _get_config('PAYBC_DIRECT_PAY_API_KEY')
     PAYBC_DIRECT_PAY_PORTAL_URL = _get_config('PAYBC_DIRECT_PAY_PORTAL_URL')
-    PAYBC_DIRECT_PAY_BASE_URL = _get_config('PAYBC_DIRECT_PAY_TRANSACTION_URL')
+    PAYBC_DIRECT_PAY_BASE_URL = _get_config('PAYBC_DIRECT_PAY_BASE_URL')
     PAYBC_DIRECT_PAY_CLIENT_ID = _get_config('PAYBC_DIRECT_PAY_CLIENT_ID')
     PAYBC_DIRECT_PAY_CLIENT_SECRET = _get_config('PAYBC_DIRECT_PAY_CLIENT_SECRET')
 
@@ -237,8 +237,8 @@ class TestConfig(_Config):  # pylint: disable=too-few-public-methods
     CFS_BASE_URL = 'http://localhost:8080/paybc-api'
     CFS_CLIENT_ID = 'TEST'
     CFS_CLIENT_SECRET = 'TEST'
-    PAYBC_PORTAL_URL = ''
-    PAYBC_DIRECT_PAY_PORTAL_URL = 'https://paydev.gov.bc.ca/public/directsale'
+    PAYBC_PORTAL_URL = 'https://paydev.gov.bc.ca/public/directpay'
+
     SERVER_NAME = 'auth-web.dev.com'
 
     REPORT_API_BASE_URL = "http://localhost:8080/reports-api/api/v1/reports"
@@ -255,6 +255,10 @@ class TestConfig(_Config):  # pylint: disable=too-few-public-methods
 
     PAYBC_DIRECT_PAY_API_KEY = 'TESTKEYSECRET'
     PAYBC_DIRECT_PAY_REF_NUMBER = 'REF1234'
+    PAYBC_DIRECT_PAY_PORTAL_URL = 'https://paydev.gov.bc.ca/public/directsale'
+    PAYBC_DIRECT_PAY_BASE_URL = 'http://localhost:8080/paybc-api'
+    PAYBC_DIRECT_PAY_CLIENT_ID = 'TEST'
+    PAYBC_DIRECT_PAY_CLIENT_SECRET = 'TEST'
 
 
 class ProdConfig(_Config):  # pylint: disable=too-few-public-methods

--- a/pay-api/src/pay_api/resources/transaction.py
+++ b/pay-api/src/pay_api/resources/transaction.py
@@ -95,7 +95,7 @@ class Transactions(Resource):
         """Update the transaction record by querying payment system."""
         current_app.logger.info(
             f'<Transaction.post for payment : {payment_id}, and transaction {transaction_id}')
-        pay_response_url: dict = request.get_json().get('payResponseUrl', None)
+        pay_response_url: str = request.get_json().get('payResponseUrl', None)
 
         try:
             response, status = TransactionService.update_transaction(payment_id, transaction_id,

--- a/pay-api/src/pay_api/services/direct_pay_service.py
+++ b/pay-api/src/pay_api/services/direct_pay_service.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 """Service to manage Direct Pay PAYBC Payments."""
 import base64
-from datetime import datetime
 from typing import Any, Dict
 from urllib.parse import unquote_plus, urlencode
 
+from dateutil import parser
 from flask import current_app
 
-from pay_api.exceptions import BusinessException
 from pay_api.models.distribution_code import DistributionCode as DistributionCodeModel
 from pay_api.models.payment_line_item import PaymentLineItem as PaymentLineItemModel
 from pay_api.services.base_payment_system import PaymentSystemService
@@ -28,14 +27,14 @@ from pay_api.services.invoice import Invoice
 from pay_api.services.invoice_reference import InvoiceReference
 from pay_api.services.payment_account import PaymentAccount
 from pay_api.utils.enums import AuthHeaderType, ContentType, PaymentSystem, PaymentMethod
-from pay_api.utils.errors import Error
-from pay_api.utils.util import parse_url_params
+from pay_api.utils.util import current_local_time, parse_url_params
 from .oauth_service import OAuthService
 from .payment_line_item import PaymentLineItem
 
 PAYBC_DATE_FORMAT = '%Y-%m-%d'
 PAYBC_REVENUE_SEPARATOR = '|'
 DECIMAL_PRECISION = '.2f'
+STATUS_PAID = 'PAID'
 
 
 class DirectPayService(PaymentSystemService, OAuthService):
@@ -43,7 +42,7 @@ class DirectPayService(PaymentSystemService, OAuthService):
 
     def get_payment_system_url(self, invoice: Invoice, inv_ref: InvoiceReference, return_url: str):
         """Return the payment system url."""
-        today = datetime.now().strftime(PAYBC_DATE_FORMAT)
+        today = current_local_time().strftime(PAYBC_DATE_FORMAT)
 
         url_params_dict = {'trnDate': today,
                            'pbcRefNumber': current_app.config.get('PAYBC_DIRECT_PAY_REF_NUMBER'),
@@ -136,24 +135,19 @@ class DirectPayService(PaymentSystemService, OAuthService):
         # If pay_response_url is present do all the pre-check, else check the status by using the invoice id
         if pay_response_url is not None:
             parsed_args = parse_url_params(pay_response_url)
-            if not parsed_args or parsed_args.get('hashValue', None) is None:
-                raise BusinessException(Error.DIRECT_PAY_INVALID_RESPONSE)
 
             # validate if hashValue matches with rest of the values hashed
-            hash_value = parsed_args.pop('hashValue', None)[0]
+            hash_value = parsed_args.pop('hashValue', None)
             pay_response_url_without_hash = urlencode(parsed_args)
-            if not HashingService.is_valid_checksum(pay_response_url_without_hash, hash_value):
-                current_app.logger.warn(f'Hash not matching for pay response URL : {pay_response_url}')
-                raise BusinessException(Error.DIRECT_PAY_INVALID_RESPONSE)
 
             # Check if trnApproved is 1=Success, 0=Declined
-            trn_approved: str = parsed_args.get('trnApproved')[0]
-            if trn_approved != '1':
-                current_app.logger.info('Returning the receipt as the transaction is not successful')
+            trn_approved: str = parsed_args.get('trnApproved')
+            if trn_approved == '1' and not HashingService.is_valid_checksum(pay_response_url_without_hash, hash_value):
+                current_app.logger.warn(f'Hash not matching for pay response URL : {pay_response_url}')
                 return None
-
             # Get the transaction number from args
-            paybc_transaction_number = parsed_args.get('trnNumber')
+            paybc_transaction_number = parsed_args.get('pbcTxnNumber')
+
         else:
             # Get the transaction number from invoice reference
             paybc_transaction_number = invoice_reference.invoice_number
@@ -167,12 +161,12 @@ class DirectPayService(PaymentSystemService, OAuthService):
         transaction_response = self.get(
             f'{paybc_transaction_url}/paybc/payment/{paybc_ref_number}/{paybc_transaction_number}',
             access_token, AuthHeaderType.BEARER, ContentType.JSON).json()
-        if transaction_response and transaction_response.get('paymentStatus') == 'PAID':
-            return transaction_response.get('trnDate'), transaction_response.get('trnAmount'), transaction_response.get(
-                'trnOrderId')
 
-        invoice = Invoice.find_by_id(invoice_reference.invoice_id, skip_auth_check=True)
-        return f'{invoice_reference.invoice_number}', datetime.now(), invoice.total
+        if transaction_response and transaction_response.get('paymentstatus') == STATUS_PAID:
+            return transaction_response.get('trnorderid'), parser.parse(
+                transaction_response.get('trndate')), float(transaction_response.get('trnamount')),
+
+        return None
 
     def __get_token(self):
         """Generate oauth token from payBC which will be used for all communication."""

--- a/pay-api/src/pay_api/services/fee_schedule.py
+++ b/pay-api/src/pay_api/services/fee_schedule.py
@@ -141,8 +141,8 @@ class FeeSchedule:  # pylint: disable=too-many-public-methods, too-many-instance
     @property
     def total(self):
         """Return the total fees calculated."""
-        return self._fee_amount + self.pst + self.gst + self.priority_fee + \
-               self.future_effective_fee + self.service_fees
+        return self._fee_amount + self.pst + self.gst + self.priority_fee + self.future_effective_fee \
+            + self.service_fees
 
     @property
     def total_excluding_service_fees(self):
@@ -297,8 +297,6 @@ class FeeSchedule:  # pylint: disable=too-many-public-methods, too-many-instance
             fee_schedule.future_effective_fee = 0
             fee_schedule.service_fees = 0
 
-        # fee_schedule.transaction_fees = Invoice.calculate_transaction_fees(account.payment_system_code, corp_type)
-
         current_app.logger.debug('>get_fees_by_corp_type_and_filing_type')
         return fee_schedule
 
@@ -329,8 +327,9 @@ class FeeSchedule:  # pylint: disable=too-many-public-methods, too-many-instance
 
         # TODO for system accounts with role EXCLUDE_SERVICE_FEES, do not charge service fees for now.
         #  Handle it properly later
-        if not user.is_staff() and not (
-                user.is_system() and Role.EXCLUDE_SERVICE_FEES.value in user.roles) and fee_schedule_model.fee.amount > 0 and fee_schedule_model.service_fee:
+        if not user.is_staff() and \
+                not (user.is_system() and Role.EXCLUDE_SERVICE_FEES.value in user.roles) \
+                and fee_schedule_model.fee.amount > 0 and fee_schedule_model.service_fee:
             service_fees = fee_schedule_model.service_fee.amount
 
         return service_fees

--- a/pay-api/src/pay_api/utils/util.py
+++ b/pay-api/src/pay_api/utils/util.py
@@ -19,14 +19,16 @@ A simple decorator to add the options method to a Request Class.
 import calendar
 from datetime import datetime, timedelta
 from typing import Dict
-from urllib.parse import parse_qs
+from urllib.parse import parse_qsl
 
+import pytz
 from dpath import util as dpath_util
 from flask import current_app
 
 
 def cors_preflight(methods: str = 'GET'):
     """Render an option method on the class."""
+
     def wrapper(f):
         def options(self, *args, **kwargs):  # pylint: disable=unused-argument
             return {'Allow': methods}, 200, \
@@ -90,6 +92,15 @@ def parse_url_params(url_params: str) -> Dict:
     if url_params is not None:
         if url_params.startswith('?'):
             url_params = url_params[1:]
-        parsed_url = parse_qs(url_params, keep_blank_values=True)
+        parsed_url = dict(parse_qsl(url_params))
 
     return parsed_url
+
+
+def current_local_time() -> datetime:
+    """Return current local time."""
+    today = datetime.now()
+    tz_name = current_app.config['LEGISLATIVE_TIMEZONE']
+    tz_local = pytz.timezone(tz_name)
+    today = today.astimezone(tz_local)
+    return today

--- a/pay-api/tests/docker/docker-compose.yml
+++ b/pay-api/tests/docker/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     image: stoplight/prism:3.3.0
     command: >
       mock -p 4010 --host 0.0.0.0
-      https://raw.githubusercontent.com/bcgov/sbc-pay/development/docs/docs/PayBC%20Mocking/paybc-1.0.0.yaml
+      https://raw.githubusercontent.com/sumesh-aot/sbc-pay/direct_pay_return/docs/docs/PayBC%20Mocking/paybc-1.0.0.yaml
   auth:
     image: stoplight/prism:3.3.0
     command: >

--- a/pay-api/tests/unit/services/test_direct_pay_service.py
+++ b/pay-api/tests/unit/services/test_direct_pay_service.py
@@ -18,12 +18,12 @@ import urllib.parse
 from datetime import date
 
 from flask import current_app
+
 from pay_api.models import DistributionCode as DistributionCodeModel
 from pay_api.models import FeeSchedule
 from pay_api.services.direct_pay_service import DirectPayService, PAYBC_DATE_FORMAT, DECIMAL_PRECISION
 from pay_api.services.distribution_code import DistributionCode
 from pay_api.services.hashing import HashingService
-
 from tests.utilities.base_test import (
     factory_invoice, factory_invoice_reference, factory_payment, factory_payment_account, factory_payment_line_item)
 from tests.utilities.base_test import get_distribution_code_payload
@@ -53,27 +53,27 @@ def test_get_payment_system_url(session, public_user_mock):
     url_param_dict = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(payment_response_url).query))
     assert url_param_dict['trnDate'] == today
     assert url_param_dict['glDate'] == today
-    assert url_param_dict['description'] == 'Direct Sale'
+    assert url_param_dict['description'] == 'Direct_Sale'
     assert url_param_dict['pbcRefNumber'] == current_app.config.get('PAYBC_DIRECT_PAY_REF_NUMBER')
     assert url_param_dict['trnNumber'] == str(invoice.id)
     assert url_param_dict['trnAmount'] == str(invoice.total)
     assert url_param_dict['paymentMethod'] == 'CC'
     assert url_param_dict['redirectUri'] == 'google.com'
     revenue_str = f"1:{distribution_code_payload['client']}." \
-                  f"{distribution_code_payload['responsibilityCentre']}." \
-                  f"{distribution_code_payload['serviceLine']}." \
-                  f"{distribution_code_payload['stob']}." \
-                  f"{distribution_code_payload['projectCode']}." \
-                  f'000000.0000:10.00'
+        f"{distribution_code_payload['responsibilityCentre']}." \
+        f"{distribution_code_payload['serviceLine']}." \
+        f"{distribution_code_payload['stob']}." \
+        f"{distribution_code_payload['projectCode']}." \
+        f'000000.0000:10.00'
     assert url_param_dict['revenue'] == revenue_str
     urlstring = f"trnDate={today}&pbcRefNumber={current_app.config.get('PAYBC_DIRECT_PAY_REF_NUMBER')}&" \
-                f'glDate={today}&description=Direct Sale&' \
-                f'trnNumber={invoice.id}&' \
-                f'trnAmount={invoice.total}&' \
-                f'paymentMethod=CC&' \
-                f'redirectUri=google.com&' \
-                f'currency=CAD&' \
-                f'revenue={revenue_str}'
+        f'glDate={today}&description=Direct_Sale&' \
+        f'trnNumber={invoice.id}&' \
+        f'trnAmount={invoice.total}&' \
+        f'paymentMethod=CC&' \
+        f'redirectUri=google.com&' \
+        f'currency=CAD&' \
+        f'revenue={revenue_str}'
     expected_hash_str = HashingService.encode(urlstring)
     assert expected_hash_str == url_param_dict['hashValue']
 
@@ -103,7 +103,7 @@ def test_get_payment_system_url_service_fees(session, public_user_mock):
     url_param_dict = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(payment_response_url).query))
     assert url_param_dict['trnDate'] == today
     assert url_param_dict['glDate'] == today
-    assert url_param_dict['description'] == 'Direct Sale'
+    assert url_param_dict['description'] == 'Direct_Sale'
     assert url_param_dict['pbcRefNumber'] == current_app.config.get('PAYBC_DIRECT_PAY_REF_NUMBER')
     assert url_param_dict['trnNumber'] == str(invoice.id)
     assert url_param_dict['trnAmount'] == str(invoice.total)
@@ -123,7 +123,7 @@ def test_get_payment_system_url_service_fees(session, public_user_mock):
         f'000000.0000:{format(service_fee, DECIMAL_PRECISION)}'
     assert url_param_dict['revenue'] == f'{revenue_str}|{revenue_str_service_fee}'
     urlstring = f"trnDate={today}&pbcRefNumber={current_app.config.get('PAYBC_DIRECT_PAY_REF_NUMBER')}&" \
-        f'glDate={today}&description=Direct Sale&' \
+        f'glDate={today}&description=Direct_Sale&' \
         f'trnNumber={invoice.id}&' \
         f'trnAmount={invoice.total}&' \
         f'paymentMethod=CC&' \
@@ -136,9 +136,11 @@ def test_get_payment_system_url_service_fees(session, public_user_mock):
     assert expected_hash_str == url_param_dict['hashValue']
 
 
-def test_get_payment_system_url_service_fees(session, public_user_mock):
-    """Assert that the url returned is correct."""
-    today = date.today().strftime(PAYBC_DATE_FORMAT)
+def test_get_receipt(session, public_user_mock):
+    """Assert that get receipt is working."""
+    response_url = 'trnApproved=1&messageText=Approved&trnOrderId=1003598&trnAmount=201.00&paymentMethod=CC' \
+                   '&cardType=VI&authCode=TEST&trnDate=2020-08-11&pbcTxnNumber=1'
+    invalid_hash = '&hashValue=0f7953db6f02f222f1285e1544c6a765'
     payment_account = factory_payment_account()
     payment = factory_payment()
     payment_account.save()
@@ -147,48 +149,17 @@ def test_get_payment_system_url_service_fees(session, public_user_mock):
     invoice.save()
     invoice_ref = factory_invoice_reference(invoice.id).save()
     fee_schedule = FeeSchedule.find_by_filing_type_and_corp_type('CP', 'OTANN')
-    distribution_code = DistributionCodeModel.find_by_active_for_fee_schedule(fee_schedule.fee_schedule_id)
-    distribution_code_svc = DistributionCode()
-    distribution_code_payload = get_distribution_code_payload()
-    # update the existing gl code with new values
-    distribution_code_svc.save_or_update(distribution_code_payload,
-                                         distribution_code.distribution_code_id)
     service_fee = 100
     line = factory_payment_line_item(invoice.id, fee_schedule_id=fee_schedule.fee_schedule_id, service_fees=service_fee)
     line.save()
     direct_pay_service = DirectPayService()
-    payment_response_url = direct_pay_service.get_payment_system_url(invoice, invoice_ref, 'google.com')
-    url_param_dict = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(payment_response_url).query))
-    assert url_param_dict['trnDate'] == today
-    assert url_param_dict['glDate'] == today
-    assert url_param_dict['description'] == 'Direct Sale'
-    assert url_param_dict['pbcRefNumber'] == current_app.config.get('PAYBC_DIRECT_PAY_REF_NUMBER')
-    assert url_param_dict['trnNumber'] == str(invoice.id)
-    assert url_param_dict['trnAmount'] == str(invoice.total)
-    assert url_param_dict['paymentMethod'] == 'CC'
-    assert url_param_dict['redirectUri'] == 'google.com'
-    revenue_str = f"1:{distribution_code_payload['client']}." \
-        f"{distribution_code_payload['responsibilityCentre']}." \
-        f"{distribution_code_payload['serviceLine']}." \
-        f"{distribution_code_payload['stob']}." \
-        f"{distribution_code_payload['projectCode']}." \
-        f'000000.0000:10.00'
-    revenue_str_service_fee = f"2:{distribution_code_payload['serviceFeeClient']}." \
-        f"{distribution_code_payload['serviceFeeResponsibilityCentre']}." \
-        f"{distribution_code_payload['serviceFeeLine']}." \
-        f"{distribution_code_payload['serviceFeeStob']}." \
-        f"{distribution_code_payload['serviceFeeProjectCode']}." \
-        f'000000.0000:{format(service_fee, DECIMAL_PRECISION)}'
-    assert url_param_dict['revenue'] == f'{revenue_str}|{revenue_str_service_fee}'
-    urlstring = f"trnDate={today}&pbcRefNumber={current_app.config.get('PAYBC_DIRECT_PAY_REF_NUMBER')}&" \
-        f'glDate={today}&description=Direct Sale&' \
-        f'trnNumber={invoice.id}&' \
-        f'trnAmount={invoice.total}&' \
-        f'paymentMethod=CC&' \
-        f'redirectUri=google.com&' \
-        f'currency=CAD&' \
-        f'revenue={revenue_str}|' \
-        f'{revenue_str_service_fee}'
-    expected_hash_str = HashingService.encode(urlstring)
+    rcpt = direct_pay_service.get_receipt(payment_account, f'{response_url}{invalid_hash}', invoice_ref)
+    assert rcpt is None
 
-    assert expected_hash_str == url_param_dict['hashValue']
+    valid_hash = f'&hashValue={HashingService.encode(response_url)}'
+    rcpt = direct_pay_service.get_receipt(payment_account, f'{response_url}{valid_hash}', invoice_ref)
+    assert rcpt is not None
+
+    # Test receipt without response_url
+    rcpt = direct_pay_service.get_receipt(payment_account, None, invoice_ref)
+    assert rcpt is not None


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/4243

*Description of changes:*
- Updating PATCH /transactions/{id} endpoint to handle return from both paybc invoiced CC payment and direct pay
- Updating paybc mock to include mock for new endpoint
- Handling all the API calls and hash validation on direct pay return

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updated the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
