### PR TITLE
fixed bug with weekly statements not getting generatd

### DIFF
--- a/pay-api/src/pay_api/models/statement_settings.py
+++ b/pay-api/src/pay_api/models/statement_settings.py
@@ -57,8 +57,7 @@ class StatementSettings(BaseModel):
     @classmethod
     def find_accounts_settings_by_frequency(cls, valid_date: datetime, frequency: StatementFrequency):
         """Return active statement setting for the account."""
-        valid_date = get_local_time(valid_date)
-
+        valid_date = get_local_time(valid_date).date()
         query = db.session.query(StatementSettings, PaymentAccount).join(PaymentAccount)
 
         query = query.filter(StatementSettings.from_date <= valid_date). \


### PR DESCRIPTION

*Issue #:*
https://github.com/bcgov/entity/issues/4896

*Description of changes:*

Stripped time information from the date comparison.The time part was causing issues with comparison and the case where weekly statement end date is today , weekly statements were not getting generated.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updated the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
