### PR TITLE
Fix for wrong start date for frequency change in statements

### DIFF
--- a/pay-api/src/pay_api/services/statement_settings.py
+++ b/pay-api/src/pay_api/services/statement_settings.py
@@ -126,7 +126,7 @@ class StatementSettings:  # pylint:disable=too-many-instance-attributes
             last_date = StatementSettings._get_end_of(max_frequency)
             all_settings.append({
                 'frequency': freq.name,
-                'start_date': last_date
+                'start_date': last_date + timedelta(days=1)
             })
 
         statements_settings_schema = StatementSettingsModelSchema()

--- a/pay-api/tests/conftest.py
+++ b/pay-api/tests/conftest.py
@@ -146,7 +146,7 @@ def session(app, db):  # pylint: disable=redefined-outer-name, invalid-name
         conn.close()
 
 
-@pytest.fixture('function')
+@pytest.fixture(scope='function')
 def client_id():
     """Return a unique client_id that can be used in tests."""
     _id = random.SystemRandom().getrandbits(0x58)

--- a/pay-api/tests/unit/api/test_statement_settings.py
+++ b/pay-api/tests/unit/api/test_statement_settings.py
@@ -58,7 +58,6 @@ def test_get_default_statement_settings_weekly(session, client, jwt, app):
                         get_first_and_last_dates_of_month(today.month, today.year)[1] + timedelta(days=1)).date()
             assert actual_monthly == expected_monthly, 'monthly matches'
         if freqeuncy.get('frequency') == StatementFrequency.DAILY.value:
-            end_date = get_week_start_and_end_date()[1]
             actual_daily = dateutil.parser.parse(freqeuncy.get('startDate')).date()
             # since current frequncy is weekly , daily changes will happen at the end of the week
             expected_weekly = (get_week_start_and_end_date()[1] + timedelta(days=1)).date()


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/5120

*Description of changes:*

UI needs the date as last date+1

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updated the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
