### PR TITLE
Handling Online Banking and PAD account creation when CFS is down

### DIFF
--- a/pay-api/src/pay_api/config.py
+++ b/pay-api/src/pay_api/config.py
@@ -103,7 +103,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     PAYBC_PORTAL_URL = _get_config('PAYBC_PORTAL_URL')
     CONNECT_TIMEOUT = int(_get_config('CONNECT_TIMEOUT', default=10))
     GENERATE_RANDOM_INVOICE_NUMBER = _get_config('CFS_GENERATE_RANDOM_INVOICE_NUMBER', default='False')
-    CFS_ACCOUNT_DESCRIPTION = _get_config('CFS_ACCOUNT_DESCRIPTION', default='BC Registries and Online Services')
+    CFS_ACCOUNT_DESCRIPTION = _get_config('CFS_ACCOUNT_DESCRIPTION', default='BCR')
 
     # PAYBC Direct Pay Settings
     PAYBC_DIRECT_PAY_REF_NUMBER = _get_config('PAYBC_DIRECT_PAY_REF_NUMBER')

--- a/pay-api/src/pay_api/models/cfs_account.py
+++ b/pay-api/src/pay_api/models/cfs_account.py
@@ -45,9 +45,10 @@ class CfsAccount(VersionedModel):  # pylint:disable=too-many-instance-attributes
     payment_account = relationship('PaymentAccount', foreign_keys=[account_id], lazy='select')
 
     @classmethod
-    def find_active_by_account_id(cls, account_id: str):
+    def find_effective_by_account_id(cls, account_id: str):
         """Return a Account by id."""
-        return cls.query.filter_by(account_id=account_id, status=CfsAccountStatus.ACTIVE.value).one_or_none()
+        return CfsAccount.query.filter(CfsAccount.account_id == account_id,
+                                       CfsAccount.status != CfsAccountStatus.INACTIVE.value).one_or_none()
 
     @classmethod
     def find_all_pending_accounts(cls):

--- a/pay-api/src/pay_api/services/base_payment_system.py
+++ b/pay-api/src/pay_api/services/base_payment_system.py
@@ -19,6 +19,7 @@ from typing import Any, Dict
 from pay_api.services.invoice import Invoice
 from pay_api.services.invoice_reference import InvoiceReference
 from pay_api.services.payment_account import PaymentAccount
+from pay_api.models import CfsAccount as CfsAccountModel
 from .payment_line_item import PaymentLineItem
 
 
@@ -34,8 +35,13 @@ class PaymentSystemService(ABC):  # pylint: disable=too-many-instance-attributes
         super(PaymentSystemService, self).__init__()
 
     @abstractmethod
-    def create_account(self, name: str, contact_info: Dict[str, Any], payment_info: Dict[str, Any], **kwargs):
+    def create_account(self, name: str, contact_info: Dict[str, Any], payment_info: Dict[str, Any],
+                       **kwargs) -> CfsAccountModel:
         """Create account in payment system."""
+
+    @abstractmethod
+    def update_account(self, cfs_account: CfsAccountModel, payment_info: Dict[str, Any]) -> CfsAccountModel:
+        """Update account in payment system."""
 
     @abstractmethod
     def create_invoice(self, payment_account: PaymentAccount, line_items: [PaymentLineItem], invoice: Invoice,

--- a/pay-api/src/pay_api/services/base_payment_system.py
+++ b/pay-api/src/pay_api/services/base_payment_system.py
@@ -40,7 +40,7 @@ class PaymentSystemService(ABC):  # pylint: disable=too-many-instance-attributes
         """Create account in payment system."""
 
     @abstractmethod
-    def update_account(self, cfs_account: CfsAccountModel, payment_info: Dict[str, Any]) -> CfsAccountModel:
+    def update_account(self, name: str, cfs_account: CfsAccountModel, payment_info: Dict[str, Any]) -> CfsAccountModel:
         """Update account in payment system."""
 
     @abstractmethod

--- a/pay-api/src/pay_api/services/bcol_service.py
+++ b/pay-api/src/pay_api/services/bcol_service.py
@@ -41,7 +41,7 @@ class BcolService(PaymentSystemService, OAuthService):
                        **kwargs) -> any:
         """Return an empty value since we don't create BC Online account."""
 
-    def update_account(self, cfs_account: any, payment_info: Dict[str, Any]) -> any:
+    def update_account(self, name: str, cfs_account: any, payment_info: Dict[str, Any]) -> any:
         """No BCOL account update."""
 
     def get_payment_system_url(self, invoice: Invoice, inv_ref: InvoiceReference, return_url: str):

--- a/pay-api/src/pay_api/services/bcol_service.py
+++ b/pay-api/src/pay_api/services/bcol_service.py
@@ -37,10 +37,12 @@ from .payment_line_item import PaymentLineItem
 class BcolService(PaymentSystemService, OAuthService):
     """Service to manage BCOL integration."""
 
-    @user_context
-    def create_account(self, name: str, contact_info: Dict[str, Any], payment_info: Dict[str, Any], **kwargs):
+    def create_account(self, name: str, contact_info: Dict[str, Any], payment_info: Dict[str, Any],
+                       **kwargs) -> any:
         """Return an empty value since we don't create BC Online account."""
-        return {}
+
+    def update_account(self, cfs_account: any, payment_info: Dict[str, Any]) -> any:
+        """No BCOL account update."""
 
     def get_payment_system_url(self, invoice: Invoice, inv_ref: InvoiceReference, return_url: str):
         """Return the payment system url."""

--- a/pay-api/src/pay_api/services/direct_pay_service.py
+++ b/pay-api/src/pay_api/services/direct_pay_service.py
@@ -116,7 +116,7 @@ class DirectPayService(PaymentSystemService, OAuthService):
                        **kwargs) -> any:
         """No Account needed for direct pay."""
 
-    def update_account(self, cfs_account: any, payment_info: Dict[str, Any]) -> any:
+    def update_account(self, name: str, cfs_account: any, payment_info: Dict[str, Any]) -> any:
         """No Account needed for direct pay."""
 
     def create_invoice(self, payment_account: PaymentAccount, line_items: [PaymentLineItem], invoice: Invoice,

--- a/pay-api/src/pay_api/services/direct_pay_service.py
+++ b/pay-api/src/pay_api/services/direct_pay_service.py
@@ -112,9 +112,12 @@ class DirectPayService(PaymentSystemService, OAuthService):
         """Return the default status for payment when created."""
         return PaymentStatus.CREATED.value
 
-    def create_account(self, name: str, contact_info: Dict[str, Any], payment_info: Dict[str, Any], **kwargs):
-        """Return an empty value since Direct Pay doesnt need any account."""
-        return {}
+    def create_account(self, name: str, contact_info: Dict[str, Any], payment_info: Dict[str, Any],
+                       **kwargs) -> any:
+        """No Account needed for direct pay."""
+
+    def update_account(self, cfs_account: any, payment_info: Dict[str, Any]) -> any:
+        """No Account needed for direct pay."""
 
     def create_invoice(self, payment_account: PaymentAccount, line_items: [PaymentLineItem], invoice: Invoice,
                        **kwargs) -> InvoiceReference:

--- a/pay-api/src/pay_api/services/internal_pay_service.py
+++ b/pay-api/src/pay_api/services/internal_pay_service.py
@@ -41,9 +41,12 @@ class InternalPayService(PaymentSystemService, OAuthService):
         """Return INTERNAL as the system code."""
         return PaymentSystem.INTERNAL.value
 
-    def create_account(self, name: str, contact_info: Dict[str, Any], payment_info: Dict[str, Any], **kwargs):
-        """Create account internal."""
-        return {}
+    def create_account(self, name: str, contact_info: Dict[str, Any], payment_info: Dict[str, Any],
+                       **kwargs) -> any:
+        """No Account needed for internal pay."""
+
+    def update_account(self, cfs_account: any, payment_info: Dict[str, Any]) -> any:
+        """No Account needed for direct pay."""
 
     def create_invoice(self, payment_account: PaymentAccount, line_items: [PaymentLineItem], invoice: Invoice,
                        **kwargs) -> InvoiceReference:

--- a/pay-api/src/pay_api/services/internal_pay_service.py
+++ b/pay-api/src/pay_api/services/internal_pay_service.py
@@ -45,7 +45,7 @@ class InternalPayService(PaymentSystemService, OAuthService):
                        **kwargs) -> any:
         """No Account needed for internal pay."""
 
-    def update_account(self, cfs_account: any, payment_info: Dict[str, Any]) -> any:
+    def update_account(self, name: str, cfs_account: any, payment_info: Dict[str, Any]) -> any:
         """No Account needed for direct pay."""
 
     def create_invoice(self, payment_account: PaymentAccount, line_items: [PaymentLineItem], invoice: Invoice,

--- a/pay-api/src/pay_api/services/online_banking_service.py
+++ b/pay-api/src/pay_api/services/online_banking_service.py
@@ -69,7 +69,7 @@ class OnlineBankingService(PaymentSystemService, CFSService):
 
         return cfs_account
 
-    def update_account(self, cfs_account: CfsAccountModel, payment_info: Dict[str, Any]) -> CfsAccountModel:
+    def update_account(self, name: str, cfs_account: CfsAccountModel, payment_info: Dict[str, Any]) -> CfsAccountModel:
         """No CFS update needed for online banking account update yet."""
 
     def create_invoice(self, payment_account: PaymentAccount, line_items: [PaymentLineItem], invoice: Invoice,

--- a/pay-api/src/pay_api/services/online_banking_service.py
+++ b/pay-api/src/pay_api/services/online_banking_service.py
@@ -20,7 +20,9 @@ from pay_api.services.invoice import Invoice
 from pay_api.services.cfs_service import CFSService
 from pay_api.services.invoice_reference import InvoiceReference
 from pay_api.services.payment_account import PaymentAccount
-from pay_api.utils.enums import PaymentSystem, PaymentMethod, InvoiceStatus, PaymentStatus
+from pay_api.models import CfsAccount as CfsAccountModel
+from pay_api.utils.enums import PaymentSystem, PaymentMethod, InvoiceStatus, PaymentStatus, CfsAccountStatus
+from pay_api.exceptions import ServiceUnavailableException
 from .payment_line_item import PaymentLineItem
 
 
@@ -47,9 +49,28 @@ class OnlineBankingService(PaymentSystemService, CFSService):
         """Return ONLINE_BANKING as the system code."""
         return PaymentMethod.ONLINE_BANKING.value
 
-    def create_account(self, name: str, contact_info: Dict[str, Any], payment_info: Dict[str, Any], **kwargs):
+    def create_account(self, name: str, contact_info: Dict[str, Any], payment_info: Dict[str, Any],
+                       **kwargs) -> CfsAccountModel:
         """Create an account for the online banking."""
-        return self.create_cfs_account(name, contact_info, receipt_method=None)  # TODO
+        try:
+            # Create CFS Account model instance and store the bank details
+            cfs_account = CfsAccountModel()
+            # Create CFS account
+            cfs_account_details = self.create_cfs_account(name, contact_info, receipt_method=None)
+            # Update model with response values
+            cfs_account.cfs_site = cfs_account_details.get('site_number')
+            cfs_account.cfs_party = cfs_account_details.get('party_number')
+            cfs_account.cfs_account = cfs_account_details.get('account_number')
+            cfs_account.status = CfsAccountStatus.ACTIVE.value
+
+        except ServiceUnavailableException as e:
+            cfs_account.status = CfsAccountStatus.PENDING.value
+            current_app.logger.warning(f'CFS Error {e}')
+
+        return cfs_account
+
+    def update_account(self, cfs_account: CfsAccountModel, payment_info: Dict[str, Any]) -> CfsAccountModel:
+        """No CFS update needed for online banking account update yet."""
 
     def create_invoice(self, payment_account: PaymentAccount, line_items: [PaymentLineItem], invoice: Invoice,
                        **kwargs) -> InvoiceReference:

--- a/pay-api/src/pay_api/services/pad_service.py
+++ b/pay-api/src/pay_api/services/pad_service.py
@@ -72,7 +72,6 @@ class PadService(PaymentSystemService, CFSService):
             cfs_account.status = CfsAccountStatus.ACTIVE.value
 
         except ServiceUnavailableException as e:
-            print('Inside catch')
             cfs_account.status = CfsAccountStatus.PENDING.value
             current_app.logger.warning(f'CFS Error {e}')
 

--- a/pay-api/src/pay_api/services/pad_service.py
+++ b/pay-api/src/pay_api/services/pad_service.py
@@ -78,7 +78,7 @@ class PadService(PaymentSystemService, CFSService):
 
         return cfs_account
 
-    def update_account(self, cfs_account: CfsAccountModel, payment_info: Dict[str, Any]) -> CfsAccountModel:
+    def update_account(self, name: str, cfs_account: CfsAccountModel, payment_info: Dict[str, Any]) -> CfsAccountModel:
         """Update account in CFS."""
         if str(payment_info.get('bankInstitutionNumber')) != cfs_account.bank_number or \
                 str(payment_info.get('bankTransitNumber')) != cfs_account.bank_branch_number or \
@@ -99,7 +99,8 @@ class PadService(PaymentSystemService, CFSService):
 
             try:
                 # Update bank information in CFS
-                bank_details = CFSService.update_bank_details(party_number=cfs_account.cfs_party,
+                bank_details = CFSService.update_bank_details(name=name,
+                                                              party_number=cfs_account.cfs_party,
                                                               account_number=cfs_account.cfs_account,
                                                               site_number=cfs_account.cfs_site,
                                                               payment_info=payment_info)

--- a/pay-api/src/pay_api/services/pad_service.py
+++ b/pay-api/src/pay_api/services/pad_service.py
@@ -13,15 +13,18 @@
 # limitations under the License.
 """Service to manage CFS Pre Authorized Debit Payments."""
 from typing import Any, Dict
+
 from flask import current_app
 
+from pay_api.exceptions import ServiceUnavailableException
+from pay_api.models import CfsAccount as CfsAccountModel
 from pay_api.services.base_payment_system import PaymentSystemService
-from pay_api.services.invoice import Invoice
 from pay_api.services.cfs_service import CFSService
+from pay_api.services.invoice import Invoice
 from pay_api.services.invoice_reference import InvoiceReference
 from pay_api.services.payment_account import PaymentAccount
-from pay_api.utils.enums import InvoiceStatus, PaymentMethod, PaymentSystem, PaymentStatus
 from pay_api.utils.constants import RECEIPT_METHOD_PAD_DAILY
+from pay_api.utils.enums import InvoiceStatus, PaymentMethod, PaymentSystem, PaymentStatus, CfsAccountStatus
 from .payment_line_item import PaymentLineItem
 
 
@@ -48,10 +51,67 @@ class PadService(PaymentSystemService, CFSService):
         """Return the default status for payment when created."""
         return PaymentStatus.CREATED.value
 
-    def create_account(self, name: str, contact_info: Dict[str, Any], payment_info: Dict[str, Any], **kwargs):
+    def create_account(self, name: str, contact_info: Dict[str, Any], payment_info: Dict[str, Any],
+                       **kwargs) -> CfsAccountModel:
         """Create an account for the PAD transactions."""
-        return self.create_cfs_account(name, contact_info, payment_info=payment_info,
-                                       receipt_method=RECEIPT_METHOD_PAD_DAILY)
+        # Create CFS Account model instance and store the bank details
+        cfs_account = CfsAccountModel()
+        cfs_account.bank_number = payment_info.get('bankInstitutionNumber')
+        cfs_account.bank_branch_number = payment_info.get('bankTransitNumber')
+        cfs_account.bank_account_number = payment_info.get('bankAccountNumber')
+
+        try:
+            # Create CFS account
+            cfs_account_details = self.create_cfs_account(name, contact_info, payment_info=payment_info,
+                                                          receipt_method=RECEIPT_METHOD_PAD_DAILY)
+            # Update model with response values
+            cfs_account.payment_instrument_number = cfs_account_details.get('payment_instrument_number', None)
+            cfs_account.cfs_account = cfs_account_details.get('account_number')
+            cfs_account.cfs_site = cfs_account_details.get('site_number')
+            cfs_account.cfs_party = cfs_account_details.get('party_number')
+            cfs_account.status = CfsAccountStatus.ACTIVE.value
+
+        except ServiceUnavailableException as e:
+            print('Inside catch')
+            cfs_account.status = CfsAccountStatus.PENDING.value
+            current_app.logger.warning(f'CFS Error {e}')
+
+        return cfs_account
+
+    def update_account(self, cfs_account: CfsAccountModel, payment_info: Dict[str, Any]) -> CfsAccountModel:
+        """Update account in CFS."""
+        if str(payment_info.get('bankInstitutionNumber')) != cfs_account.bank_number or \
+                str(payment_info.get('bankTransitNumber')) != cfs_account.bank_branch_number or \
+                str(payment_info.get('bankAccountNumber')) != cfs_account.bank_account_number:
+            # Make the current CFS Account as INACTIVE in DB
+            cfs_account.status = CfsAccountStatus.INACTIVE.value
+            cfs_account.flush()
+
+            # Create new CFS Account
+            updated_cfs_account = CfsAccountModel()
+            updated_cfs_account.bank_account_number = payment_info.get('bankAccountNumber')
+            updated_cfs_account.bank_number = payment_info.get('bankInstitutionNumber')
+            updated_cfs_account.bank_branch_number = payment_info.get('bankTransitNumber')
+            updated_cfs_account.cfs_site = cfs_account.cfs_site
+            updated_cfs_account.cfs_party = cfs_account.cfs_party
+            updated_cfs_account.cfs_account = cfs_account.cfs_account
+            updated_cfs_account.payment_account = cfs_account.payment_account
+
+            try:
+                # Update bank information in CFS
+                bank_details = CFSService.update_bank_details(party_number=cfs_account.cfs_party,
+                                                              account_number=cfs_account.cfs_account,
+                                                              site_number=cfs_account.cfs_site,
+                                                              payment_info=payment_info)
+                updated_cfs_account.payment_instrument_number = bank_details.get('payment_instrument_number', None)
+                updated_cfs_account.status = CfsAccountStatus.ACTIVE.value
+            except ServiceUnavailableException as e:
+                updated_cfs_account.status = CfsAccountStatus.PENDING.value
+                current_app.logger.warning(f'CFS Error {e}')
+
+            updated_cfs_account.flush()
+            return updated_cfs_account
+        return cfs_account
 
     def create_invoice(self, payment_account: PaymentAccount, line_items: [PaymentLineItem], invoice: Invoice,
                        **kwargs) -> InvoiceReference:

--- a/pay-api/src/pay_api/services/paybc_service.py
+++ b/pay-api/src/pay_api/services/paybc_service.py
@@ -76,8 +76,8 @@ class PaybcService(PaymentSystemService, CFSService):
         cfs_account.status = CfsAccountStatus.ACTIVE.value
         return cfs_account
 
-    def update_account(self, cfs_account: any, payment_info: Dict[str, Any]) -> any:
-        """No BCOL account update."""
+    def update_account(self, name: str, cfs_account: any, payment_info: Dict[str, Any]) -> any:
+        """No CFS account update."""
 
     def complete_post_invoice(self, invoice_id: int, invoice_reference: InvoiceReference) -> None:
         """Complete any post invoice activities if needed."""

--- a/pay-api/src/pay_api/services/payment_account.py
+++ b/pay-api/src/pay_api/services/payment_account.py
@@ -310,7 +310,8 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
             # If the account is PAD and bank details changed, then update bank details
             else:
                 # Update details in CFS
-                pay_system.update_account(cfs_account=cfs_account, payment_info=payment_info)
+                pay_system.update_account(name=payment_account.auth_account_name, cfs_account=cfs_account,
+                                          payment_info=payment_info)
 
         payment_account.save()
 

--- a/pay-api/tests/unit/services/test_pad_service.py
+++ b/pay-api/tests/unit/services/test_pad_service.py
@@ -31,7 +31,7 @@ def test_create_account(session):
     }
     account = pad_service.create_account(name='Test Account', contact_info={}, payment_info=payment_info)
     assert account
-    assert account.get('bank_number') == payment_info.get('bankInstitutionNumber')
+    assert account.bank_number == payment_info.get('bankInstitutionNumber')
 
 
 def test_get_payment_system_url(session):

--- a/pay-api/tests/unit/services/test_payment_system_service.py
+++ b/pay-api/tests/unit/services/test_payment_system_service.py
@@ -29,6 +29,7 @@ def test_base_payment_system(session):
         (PaymentSystemService, object),
         {
             'create_account': lambda self: print('Inside create_account'),
+            'update_account': lambda self: print('Inside update_account'),
             'create_invoice': lambda self: print('Inside create_invoice'),
             'update_invoice': lambda self: print('Inside update_invoice'),
             'cancel_invoice': lambda self: print('Inside cancel_invoice'),

--- a/pay-api/tests/utilities/base_test.py
+++ b/pay-api/tests/utilities/base_test.py
@@ -18,6 +18,7 @@ Test-Suite to ensure that the /payments endpoint is working as expected.
 """
 
 from datetime import datetime
+from random import randrange
 
 from pay_api.models import (CfsAccount,
                             Invoice,
@@ -498,7 +499,8 @@ def get_basic_account_payload(payment_method: str = PaymentMethod.DIRECT_PAY.val
     }
 
 
-def get_premium_account_payload(payment_method: str = PaymentMethod.DRAWDOWN.value, account_id: int = 1234):
+def get_premium_account_payload(payment_method: str = PaymentMethod.DRAWDOWN.value,
+                                account_id: int = randrange(999999)):
     """Return a premium payment account object."""
     return {
         'accountId': account_id,
@@ -512,7 +514,7 @@ def get_premium_account_payload(payment_method: str = PaymentMethod.DRAWDOWN.val
     }
 
 
-def get_pad_account_payload(account_id: int = 1234, bank_number: str = '001', transit_number='999',
+def get_pad_account_payload(account_id: int = randrange(999999), bank_number: str = '001', transit_number='999',
                             bank_account='1234567890'):
     """Return a pad payment account object."""
     return {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/4776

*Description of changes:*
- Handling CFS down scenario for Online Banking and PAD accounts
- Return 202 if CFS is down
- Return 201 if CFS is up for POST
- Return 200 is CFS is up for PUT

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updated the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
