### PR TITLE
Bank validation error handled

### DIFF
--- a/docs/docs/PayBC Mocking/paybc-1.0.0.yaml
+++ b/docs/docs/PayBC Mocking/paybc-1.0.0.yaml
@@ -482,7 +482,7 @@ paths:
               $ref: '#/components/schemas/Bank_info'
         required: true
       responses:
-        '201':
+        '200':
           description: Created
           content:
             application/json:

--- a/pay-api/src/pay_api/services/cfs_service.py
+++ b/pay-api/src/pay_api/services/cfs_service.py
@@ -78,7 +78,7 @@ class CFSService(OAuthService):
                     'transit_address': bank_validation_response.get('transit_address', None),
                     'account_number': bank_validation_response.get('account_number', None),
                     'is_valid': bank_validation_response.get('CAS-Returned-Messages', None) == 'VALID',
-                    'status_code': HTTPStatus.OK,
+                    'status_code': HTTPStatus.OK.value,
                     'message': CFSService._transform_error_message(
                         bank_validation_response.get('CAS-Returned-Messages'))
                 }
@@ -86,14 +86,14 @@ class CFSService(OAuthService):
                 current_app.logger.debug('<Bank validation HTTP exception- {}', bank_validation_response_obj.text)
                 validation_response = {
                     'status_code': bank_validation_response_obj.status_code,
-                    'msessage': 'Bank validation service cant be reached'
+                    'message': 'Bank validation service cant be reached'
                 }
 
         except ServiceUnavailableException as exc:  # suppress all other errors
             current_app.logger.debug('<Bank validation ServiceUnavailableException exception- {}', exc.error)
             validation_response = {
                 'status_code': HTTPStatus.SERVICE_UNAVAILABLE.value,
-                'msessage': exc.error
+                'message': str(exc.error)
             }
 
         return validation_response

--- a/pay-api/tests/docker/docker-compose.yml
+++ b/pay-api/tests/docker/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     image: stoplight/prism:3.3.0
     command: >
       mock -p 4010 --host 0.0.0.0
-      https://raw.githubusercontent.com/bcgov/sbc-pay/development/docs/docs/PayBC%20Mocking/paybc-1.0.0.yaml
+      https://raw.githubusercontent.com/bcgov/sbc-pay/bankvalidation/docs/docs/PayBC%20Mocking/paybc-1.0.0.yaml
   auth:
     image: stoplight/prism:3.3.0
     command: >

--- a/pay-api/tests/docker/docker-compose.yml
+++ b/pay-api/tests/docker/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     image: stoplight/prism:3.3.0
     command: >
       mock -p 4010 --host 0.0.0.0
-      https://raw.githubusercontent.com/saravanpa-aot/sbc-pay/development/docs/docs/PayBC%20Mocking/paybc-1.0.0.yaml
+      https://raw.githubusercontent.com/bcgov/sbc-pay/development/docs/docs/PayBC%20Mocking/paybc-1.0.0.yaml
   auth:
     image: stoplight/prism:3.3.0
     command: >

--- a/pay-api/tests/unit/services/test_cfs_service.py
+++ b/pay-api/tests/unit/services/test_cfs_service.py
@@ -18,10 +18,8 @@ Test-Suite to ensure that the CFS Service layer is working as expected.
 """
 from unittest.mock import patch
 
-import pytest
 from requests import ConnectTimeout
 
-from pay_api.exceptions import ServiceUnavailableException
 from pay_api.services.cfs_service import CFSService
 
 cfs_service = CFSService()


### PR DESCRIPTION
* Bank validation errors are fixed

*Issue #:*
https://github.com/bcgov/entity/issues/4773

*Description of changes:*

- The CFS API returns 400  with a payload for the invalid bank account details. So checked 200 or 400 for error status. 

- handled the errors in the backend and returned a graceful response so that its easier to handle it in the front end .

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updated the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
