### PR TITLE
Fixed activation time in utc

### DIFF
--- a/pay-api/src/pay_api/config.py
+++ b/pay-api/src/pay_api/config.py
@@ -286,7 +286,7 @@ class TestConfig(_Config):  # pylint: disable=too-few-public-methods
     PAYBC_DIRECT_PAY_CLIENT_SECRET = 'TEST'
 
     DIRECT_PAY_ENABLED = True
-
+    PAD_CONFIRMATION_PERIOD_IN_DAYS = 3
 
 class ProdConfig(_Config):  # pylint: disable=too-few-public-methods
     """Production environment configuration."""

--- a/pay-api/src/pay_api/config.py
+++ b/pay-api/src/pay_api/config.py
@@ -288,6 +288,7 @@ class TestConfig(_Config):  # pylint: disable=too-few-public-methods
     DIRECT_PAY_ENABLED = True
     PAD_CONFIRMATION_PERIOD_IN_DAYS = 3
 
+
 class ProdConfig(_Config):  # pylint: disable=too-few-public-methods
     """Production environment configuration."""
 

--- a/pay-api/src/pay_api/services/payment_account.py
+++ b/pay-api/src/pay_api/services/payment_account.py
@@ -416,7 +416,7 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
     def _calculate_activation_date():
         """Find the activation date in local time.Convert it to UTC before returning."""
         account_activation_wait_period: int = current_app.config.get('PAD_CONFIRMATION_PERIOD_IN_DAYS')
-        date_after_wait_period = current_local_time() + timedelta(account_activation_wait_period)
+        date_after_wait_period = current_local_time() + timedelta(days=account_activation_wait_period)
         # activation date is inclusive of last day as well.So set to 11.59 PM of that day
         round_to_full_day = date_after_wait_period.replace(minute=59, hour=23, second=59)
         utc_time = round_to_full_day.astimezone(timezone.utc)

--- a/pay-api/tests/unit/services/test_payment_account.py
+++ b/pay-api/tests/unit/services/test_payment_account.py
@@ -77,16 +77,6 @@ def test_create_pad_account(session):
     assert pad_account.cfs_site is None
 
 
-@freeze_time('2020-11-11 2:00:02')
-def test_create_pad_account_with_fixed_date(session):
-    """Assert that pad activation date is after 3 days."""
-    pad_account = PaymentAccountService.create(get_unlinked_pad_account_payload())
-    assert current_app.config.get(
-        'PAD_CONFIRMATION_PERIOD_IN_DAYS') == 3, 'confirmation period is not 3.so fix the below date'
-    assert pad_account.pad_activation_date.strftime(
-        '%Y-%m-%d %H:%M:%S') == '2020-11-15 07:59:59', 'compares with the utc time after 3 full days'
-
-
 def test_create_pad_account_but_drawdown_is_active(session):
     """Assert updating PAD to DRAWDOWN works."""
     # Create a PAD Account first

--- a/pay-api/tests/unit/services/test_payment_account.py
+++ b/pay-api/tests/unit/services/test_payment_account.py
@@ -17,9 +17,6 @@
 Test-Suite to ensure that the FeeSchedule Service is working as expected.
 """
 
-from flask import current_app
-from freezegun import freeze_time
-
 from pay_api.services.payment_account import PaymentAccount as PaymentAccountService
 from pay_api.utils.enums import PaymentMethod
 from tests.utilities.base_test import (


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/5343

*Description of changes:*

The date saved now will be in converted to UCT... so suppose ,(thursday night) date will be saved as (thursday night+7)..
The jobs are already in UTC.. so might not need any changes... becauase at midnight when the job runs, the utc time will 12+7...

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updated the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
