### PR TITLE
Fix for linked PAD accounts not creating cfs table entries

### DIFF
--- a/pay-api/src/pay_api/services/payment_account.py
+++ b/pay-api/src/pay_api/services/payment_account.py
@@ -311,11 +311,6 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
         payment_account.pad_tos_accepted_by = account_request.get('padTosAcceptedBy', None)
         payment_account.pad_tos_accepted_date = datetime.now()
 
-        if not payment_method or payment_method == PaymentMethod.PAD.value:
-            payment_method, activation_date = PaymentAccount._get_payment_based_on_pad_activation(payment_account)
-            payment_account.pad_activation_date = activation_date
-            payment_account.payment_method = payment_method
-
         payment_info = account_request.get('paymentInfo')
         billable = payment_info.get('billable', True)
         payment_account.billable = billable
@@ -344,6 +339,13 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
                 pay_system.update_account(name=payment_account.auth_account_name, cfs_account=cfs_account,
                                           payment_info=payment_info)
 
+        is_pad = payment_method == PaymentMethod.PAD.value
+        if is_pad:
+            # override payment method for since pad has 3 days wait period
+            effective_pay_method, activation_date = PaymentAccount._get_payment_based_on_pad_activation(payment_account)
+            payment_account.pad_activation_date = activation_date
+            payment_account.payment_method = effective_pay_method
+
         payment_account.save()
 
     @classmethod
@@ -366,14 +368,19 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
         is_first_time_pad = not account.pad_activation_date
         is_unlinked_premium = not account.bcol_account
         # default it. If ever was in PAD , no new activation date needed
-        new_activation_date = account.pad_activation_date
         if is_first_time_pad:
             new_payment_method = PaymentMethod.PAD.value if is_unlinked_premium else PaymentMethod.DRAWDOWN.value
             new_activation_date = PaymentAccount._calculate_activation_date()
         else:
-            # Handle repeated changing of pad to bcol ;then to pad again
+            # Handle repeated changing of pad to bcol ;then to pad again etc
+            new_activation_date = account.pad_activation_date  # was already in pad ;no need to extend
             is_previous_pad_activated = account.pad_activation_date < datetime.now()
-            new_payment_method = PaymentMethod.PAD.value if is_previous_pad_activated else PaymentMethod.DRAWDOWN.value
+            if is_previous_pad_activated:
+                # was in PAD ; so no need of activation period wait time and no need to be in bcol..so use PAD again
+                new_payment_method = PaymentMethod.PAD.value
+            else:
+                # was in pad and not yet activated ;but changed again within activation period
+                new_payment_method = PaymentMethod.PAD.value if is_unlinked_premium else PaymentMethod.DRAWDOWN.value
 
         return new_payment_method, new_activation_date
 

--- a/pay-api/tests/unit/services/test_payment_account.py
+++ b/pay-api/tests/unit/services/test_payment_account.py
@@ -80,6 +80,7 @@ def test_create_pad_account_but_drawdown_is_active(session):
     pad_account = PaymentAccountService.create(get_pad_account_payload())
     # Update this payment account with drawdown and assert payment method
     assert pad_account.payment_method == PaymentMethod.DRAWDOWN.value
+    assert pad_account.cfs_account_id
 
 
 def test_create_pad_account_to_drawdown(session):


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*

The bug was caused by the setting of payment type as draw down TOO EARLY. [drawdown is the effective payment method since the pad is in activation period and draw down takes precedence] . Since it was set as drawdown , the cfs account creation logic wouldnt execute. 
This is fixed by simply moving the logic to the end of the block so that no other things are affected.
Added a test as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
