### PR TITLE
added the pad tos accepted user id in event reponse , masking corrected

### DIFF
--- a/jobs/payment-jobs/tasks/cfs_create_account_task.py
+++ b/jobs/payment-jobs/tasks/cfs_create_account_task.py
@@ -49,7 +49,6 @@ class CreateAccountTask:  # pylint: disable=too-few-public-methods
         auth_token = get_token()
 
         for pending_account in pending_accounts:
-            is_create_account: bool = True
             # Find the payment account and create the pay system instance.
             pay_account: PaymentAccountModel = PaymentAccountModel.find_by_id(pending_account.account_id)
             current_app.logger.info(
@@ -82,7 +81,6 @@ class CreateAccountTask:  # pylint: disable=too-few-public-methods
                                                                   site_number=pending_account.cfs_site,
                                                                   payment_info=payment_info)
                     pending_account.payment_instrument_number = bank_details.get('payment_instrument_number', None)
-                    is_create_account = False
                 else:  # It's a new account, now create
                     # If the account have banking information, then create a PAD account else a regular account.
                     if pending_account.bank_number and pending_account.bank_branch_number \
@@ -116,7 +114,6 @@ class CreateAccountTask:  # pylint: disable=too-few-public-methods
             pending_account.status = CfsAccountStatus.PENDING_PAD_ACTIVATION.value if \
                 is_account_in_pad_confirmation_period else CfsAccountStatus.ACTIVE.value
             pending_account.save()
-
 
     @classmethod
     def _get_account_contact(cls, auth_token: str, auth_account_id: str):

--- a/pay-api/src/pay_api/services/payment_account.py
+++ b/pay-api/src/pay_api/services/payment_account.py
@@ -44,6 +44,7 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
         self._payment_method: Union[None, str] = None
         self._auth_account_name: Union[None, str] = None
         self._pad_activation_date: Union[None, datetime] = None
+        self._pad_tos_accepted_by: Union[None, str] = None
 
         self._cfs_account: Union[None, str] = None
         self._cfs_party: Union[None, str] = None
@@ -77,6 +78,7 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
         self.bcol_user_id: str = self._dao.bcol_user_id
         self.bcol_account: str = self._dao.bcol_account
         self.pad_activation_date: datetime = self._dao.pad_activation_date
+        self.pad_tos_accepted_by: str = self._dao.pad_tos_accepted_by
 
         cfs_account: CfsAccountModel = CfsAccountModel.find_effective_by_account_id(self.id)
         if cfs_account:
@@ -240,14 +242,25 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
 
     @property
     def pad_activation_date(self):
-        """Return the bcol_user_id."""
+        """Return the pad_activation_date."""
         return self._pad_activation_date
 
     @pad_activation_date.setter
     def pad_activation_date(self, value: datetime):
-        """Set the bcol_user_id."""
+        """Set the pad_activation_date."""
         self._pad_activation_date = value
         self._dao.pad_activation_date = value
+
+    @property
+    def pad_tos_accepted_by(self):
+        """Return the pad_tos_accepted_by."""
+        return self._pad_tos_accepted_by
+
+    @pad_tos_accepted_by.setter
+    def pad_tos_accepted_by(self, value: datetime):
+        """Set the pad_tos_accepted_by."""
+        self._pad_tos_accepted_by = value
+        self._dao.pad_tos_accepted_by = value
 
     @property
     def bcol_account(self):
@@ -486,6 +499,7 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
             'data': {
                 'accountId': self.auth_account_id,
                 'accountName': self.auth_account_name,
+                'padTosAcceptedBy': self.pad_tos_accepted_by
             }
         }
 
@@ -493,7 +507,7 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
             payload['data']['paymentInfo'] = dict(
                 bankInstitutionNumber=self.bank_number,
                 bankTransitNumber=self.bank_branch_number,
-                bankAccountNumber=self.bank_account_number,
+                bankAccountNumber=mask(self.bank_account_number, current_app.config['MASK_LEN']),
                 paymentStartDate=get_local_formatted_date(self.pad_activation_date))
         return payload
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/5779

*Description of changes:*

1) added pad tos user id so that account mailer can use to address the account creator
2) removed the event which is not needed
3) corrected masking


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
