### PR TITLE
deactivte cfs account when goes to bcol

### DIFF
--- a/pay-api/src/pay_api/services/payment_account.py
+++ b/pay-api/src/pay_api/services/payment_account.py
@@ -352,6 +352,11 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
                 pay_system.update_account(name=payment_account.auth_account_name, cfs_account=cfs_account,
                                           payment_info=payment_info)
 
+        elif cfs_account is not None:
+            # if its not PAYBC ,it means switching to either drawdown or internal ,deactivate the cfs account
+            cfs_account.status = CfsAccountStatus.INACTIVE.value
+            cfs_account.flush()
+
         is_pad = payment_method == PaymentMethod.PAD.value
         if is_pad:
             # override payment method for since pad has 3 days wait period

--- a/pay-api/tests/unit/api/test_account.py
+++ b/pay-api/tests/unit/api/test_account.py
@@ -238,7 +238,7 @@ def test_premium_account_update_bcol_pad(session, client, jwt, app):
     assert rv.json.get('authAccountId') == auth_account_id
 
     # assert switching to PAD returns bank details
-    pad_account_details = get_pad_account_payload()
+    pad_account_details = get_pad_account_payload(account_id=int(auth_account_id))
 
     rv = client.put(f'/api/v1/accounts/{auth_account_id}', data=json.dumps(pad_account_details),
                     headers=headers)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/5095

*Description of changes:*
the logic is to put cfs_account to inactive if the `if pay_system.get_payment_system_code() == PaymentSystem.PAYBC.value:` is false. I hope that works and wont break anything else 

An update/creation of payment account comes and if system code is not PAYBC , we will set cfsaccount to inactive


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
