### PR TITLE
returning message as a list incase of error scenarios

### DIFF
--- a/pay-api/src/pay_api/services/cfs_service.py
+++ b/pay-api/src/pay_api/services/cfs_service.py
@@ -119,14 +119,14 @@ class CFSService(OAuthService):
                 current_app.logger.debug('<Bank validation HTTP exception- {}', bank_validation_response_obj.text)
                 validation_response = {
                     'status_code': bank_validation_response_obj.status_code,
-                    'message': 'Bank validation service cant be reached'
+                    'message': ['Bank validation service cant be reached']
                 }
 
         except ServiceUnavailableException as exc:  # suppress all other errors
             current_app.logger.debug('<Bank validation ServiceUnavailableException exception- {}', exc.error)
             validation_response = {
                 'status_code': HTTPStatus.SERVICE_UNAVAILABLE.value,
-                'message': str(exc.error)
+                'message': [str(exc.error)]
             }
 
         return validation_response


### PR DESCRIPTION

*Description of changes:*

A fix related to a UI bug. Not necessarily need to be fixed here ;but for the sake of consistency , fixing it here.
service returns the validation messages as a list when CFS is available and validation is carried out successfully.But when the CFS is down , it was returning single string message. Thats been changed. 
The error message when CFS is not supposed to be used by UI ;but because of a bug it's been read and it failed  because it expected a list.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
