### PR TITLE
removed paymentMethodDescription from reciept schema so that Nr is not failing

### DIFF
--- a/pay-api/src/pay_api/resources/invoice_receipt.py
+++ b/pay-api/src/pay_api/resources/invoice_receipt.py
@@ -65,8 +65,10 @@ class InvoiceReceipt(Resource):
         """Return the receipt details."""
         current_app.logger.info('<Receipt.post')
         try:
-            response = ReceiptService.get_receipt_details({}, invoice_id, skip_auth_check=False)
+            receipt_details = ReceiptService.get_receipt_details({}, invoice_id, skip_auth_check=False)
+            receipt_details.pop('paymentMethodDescription', None)
+
         except BusinessException as exception:
             return exception.response()
         current_app.logger.debug('>Transaction.post')
-        return jsonify(response), 200
+        return jsonify(receipt_details), 200


### PR DESCRIPTION
Riaz found out that Nr reciepts are failing with below error .

{“message”:”SBC Pay API exception.\r\n\r\n__init__() got an unexpected keyword argument ‘paymentMethodDescription’”}

I think they are checking  schema in their side .So this is a fix to address the issue.


*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
