### PR TITLE
Fixing issue with setting wrong status for JV distribution.

### DIFF
--- a/queue_services/payment-reconciliations/requirements.txt
+++ b/queue_services/payment-reconciliations/requirements.txt
@@ -1,6 +1,7 @@
 Flask==1.1.2
 Jinja2==2.11.3
 MarkupSafe==1.1.1
+SQLAlchemy==1.3.23
 Werkzeug==0.16.1
 asyncio-nats-client==0.11.4
 asyncio-nats-streaming==0.4.0
@@ -13,16 +14,16 @@ jaeger-client==4.4.0
 jsonschema==3.2.0
 minio==7.0.2
 opentracing==2.4.0
-protobuf==3.15.2
+protobuf==3.15.6
 pycountry==20.7.3
 pyrsistent==0.17.3
 python-dotenv==0.15.0
-sentry-sdk==0.20.3
+sentry-sdk==1.0.0
 six==1.15.0
 threadloop==1.0.2
 thrift==0.13.0
 tornado==6.1
-urllib3==1.26.3
+urllib3==1.26.4
 -e git+https://github.com/bcgov/lear.git#egg=entity_queue_common&subdirectory=queue_services/common
 -e git+https://github.com/bcgov/sbc-common-components.git#egg=sbc-common-components&subdirectory=python
 -e git+https://github.com/bcgov/sbc-pay.git#egg=pay-api&subdirectory=pay-api

--- a/queue_services/payment-reconciliations/requirements/prod.txt
+++ b/queue_services/payment-reconciliations/requirements/prod.txt
@@ -9,3 +9,4 @@ Werkzeug<1
 minio
 jaeger-client
 attrs==19.1.0
+sqlalchemy<1.4

--- a/queue_services/payment-reconciliations/src/reconciliations/ejv_reconciliations.py
+++ b/queue_services/payment-reconciliations/src/reconciliations/ejv_reconciliations.py
@@ -122,13 +122,14 @@ async def _update_feedback(msg: Dict[str, any]):  # pylint:disable=too-many-loca
 
             invoice_return_code = line[315:319]
             invoice_return_message = line[319:469]
-            invoice_link.disbursement_status_code = _get_disbursement_status(invoice_return_code)
-            invoice_link.message = invoice_return_message
-            invoice.disbursement_status_code = _get_disbursement_status(invoice_return_code)
             # If the JV process failed, then mark the GL code against the invoice to be stopped
             # for further JV process for the credit GL.
             is_credit: bool = line[104:105] == 'C'
             if is_credit:
+                invoice_link.disbursement_status_code = _get_disbursement_status(invoice_return_code)
+                invoice_link.message = invoice_return_message
+                invoice.disbursement_status_code = _get_disbursement_status(invoice_return_code)
+
                 line_items: List[PaymentLineItemModel] = invoice.payment_line_items
                 for line_item in line_items:
                     # Line debit distribution


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/6351

*Description of changes:*
- Reconciliation was changing the status on both credit and debit, fixed it to set it only for credits as debit is always registry GL code


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
