### PR TITLE
changed initiator, date fields and return all

### DIFF
--- a/pay-api/src/pay_api/models/routing_slip.py
+++ b/pay-api/src/pay_api/models/routing_slip.py
@@ -87,7 +87,7 @@ class RoutingSlip(Audit):  # pylint: disable=too-many-instance-attributes
 
         query = query.join(PaymentAccount)
         if initiator := search_filter.get('initiator', None):
-            query = query.filter(PaymentAccount.name.ilike('%' + initiator + '%'))
+            query = query.filter(RoutingSlip.created_name.ilike('%' + initiator + '%'))
 
         query = cls._add_receipt_number(query, search_filter)
 
@@ -129,7 +129,8 @@ class RoutingSlip(Audit):  # pylint: disable=too-many-instance-attributes
             created_from = created_from.replace(hour=0, minute=0, second=0, microsecond=0).astimezone(tz_local)
             created_to = created_to.replace(hour=23, minute=59, second=59, microsecond=999999).astimezone(tz_local)
             query = query.filter(
-                func.timezone(tz_name, func.timezone('UTC', RoutingSlip.created_on)).between(created_from, created_to))
+                func.timezone(tz_name, func.timezone('UTC', RoutingSlip.routing_slip_date))
+                    .between(created_from, created_to))
         return query
 
     @classmethod

--- a/pay-api/src/pay_api/resources/fas/routing_slip.py
+++ b/pay-api/src/pay_api/resources/fas/routing_slip.py
@@ -67,21 +67,23 @@ class RoutingSlipSearch(Resource):
     @_tracing.trace()
     def post():
         """Get routing slips."""
-        current_app.logger.info('<RoutingSlips.post')
+        current_app.logger.info('<RoutingSlips.query.post')
         request_json = request.get_json()
         current_app.logger.debug(request_json)
-        page: int = int(request.args.get('page', '1'))
-        limit: int = int(request.args.get('limit', '10'))
         # validate the request
         valid_format, errors = schema_utils.validate(request_json, 'routing_slip_search_request')
         if not valid_format:
             return error_to_response(Error.INVALID_REQUEST, invalid_params=schema_utils.serialize(errors))
 
+        # if no page param , return all results
+        if not request.args.get('page', None):
+            return_all = True
+
         page: int = int(request.args.get('page', '1'))
         limit: int = int(request.args.get('limit', '10'))
         response, status = RoutingSlipService.search(request_json, page,
-                                                     limit), HTTPStatus.OK
-        current_app.logger.debug('>AccountPurchaseHistory.post')
+                                                     limit, return_all=return_all), HTTPStatus.OK
+        current_app.logger.debug('>RoutingSlips.query.post')
         return jsonify(response), status
 
 

--- a/pay-api/tests/unit/api/fas/test_routing_slip.py
+++ b/pay-api/tests/unit/api/fas/test_routing_slip.py
@@ -51,10 +51,11 @@ def test_create_routing_slips(session, client, jwt, app, payload):
 
 def test_create_routing_slips_search(session, client, jwt, app):
     """Assert that the search works."""
-    token = jwt.create_jwt(get_claims(roles=[Role.FAS_CREATE.value, Role.FAS_SEARCH.value]), token_header)
+    claims = get_claims(roles=[Role.FAS_CREATE.value, Role.FAS_SEARCH.value])
+    token = jwt.create_jwt(claims, token_header)
     headers = {'Authorization': f'Bearer {token}', 'content-type': 'application/json'}
     payload = get_routing_slip_request()
-    initiator = payload.get('paymentAccount').get('accountName')
+    initiator = claims.get('name')
     rv = client.post('/api/v1/fas/routing-slips', data=json.dumps(payload), headers=headers)
     assert rv.status_code == 201
     rs_number = rv.json.get('number')

--- a/pay-api/tests/utilities/base_test.py
+++ b/pay-api/tests/utilities/base_test.py
@@ -56,6 +56,7 @@ def get_claims(app_request=None, role: str = Role.EDITOR.value, username: str = 
                     ]
             },
         'preferred_username': username,
+        'name': username,
         'username': username,
         'loginSource': login_source,
         'roles':


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/8104

*Description of changes:*

- defaulted return all to true if no pagination is passed.

- As discussed in UX meeting, changes from our original plan

initiator is the staff who creates the routing slip
date filter is for the routing slip date.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
