### PR TITLE
auth_response None

### DIFF
--- a/pay-api/src/pay_api/services/auth.py
+++ b/pay-api/src/pay_api/services/auth.py
@@ -26,7 +26,6 @@ def check_auth(business_identifier: str, account_id: str = None, corp_type_code:
     """Authorize the user for the business entity and return authorization response."""
     user: UserContext = kwargs['user']
     is_authorized: bool = False
-    # test
     auth_response = None
 
     if not account_id:
@@ -62,6 +61,7 @@ def check_auth(business_identifier: str, account_id: str = None, corp_type_code:
             g.account_id = auth_response.get('account').get('id') if auth_response.get('account', None) else None
         elif Role.STAFF.value in user.roles:
             roles: list = user.roles
+            auth_response = {}
 
         g.user_permission = auth_response.get('roles')
         if kwargs.get('one_of_roles', None):

--- a/pay-api/src/pay_api/services/auth.py
+++ b/pay-api/src/pay_api/services/auth.py
@@ -26,7 +26,7 @@ def check_auth(business_identifier: str, account_id: str = None, corp_type_code:
     """Authorize the user for the business entity and return authorization response."""
     user: UserContext = kwargs['user']
     is_authorized: bool = False
-    auth_response = None
+    auth_response = {}
 
     if not account_id:
         account_id = user.account_id

--- a/pay-api/src/pay_api/services/auth.py
+++ b/pay-api/src/pay_api/services/auth.py
@@ -26,7 +26,8 @@ def check_auth(business_identifier: str, account_id: str = None, corp_type_code:
     """Authorize the user for the business entity and return authorization response."""
     user: UserContext = kwargs['user']
     is_authorized: bool = False
-    auth_response = {}
+    # test
+    auth_response = None
 
     if not account_id:
         account_id = user.account_id

--- a/pay-api/tests/utilities/base_test.py
+++ b/pay-api/tests/utilities/base_test.py
@@ -103,6 +103,27 @@ def get_payment_request(business_identifier: str = 'CP0001234', corp_type: str =
     }
 
 
+def get_payment_request_without_bn(corp_type: str = 'CP',
+                                   filing_type: str = 'OTADD'):
+    """Return a payment request object."""
+    return {
+        'businessInfo': {
+            'corpType': corp_type
+        },
+        'filingInfo': {
+            'filingTypes': [
+                {
+                    'filingTypeCode': filing_type,
+                    'filingDescription': 'TEST'
+                },
+                {
+                    'filingTypeCode': 'OTANN'
+                }
+            ]
+        }
+    }
+
+
 def get_payment_request_with_service_fees(business_identifier: str = 'CP0001234', corp_type: str = 'BEN',
                                           filing_type: str = 'BCINC'):
     """Return a payment request object."""


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/8659

*Description of changes:*

When the businessId is empty , we wont call auth and auth_response will be None.so auth_response is set to empty dict to avoid breaking further code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
