### PR TITLE
formatted currency output in error message

### DIFF
--- a/pay-api/src/pay_api/exceptions/__init__.py
+++ b/pay-api/src/pay_api/exceptions/__init__.py
@@ -58,6 +58,8 @@ class BusinessException(Exception):  # noqa
         super(BusinessException, self).__init__(*args, **kwargs)  # pylint:disable=super-with-arguments
         self.code = error.code
         self.status = error.status
+        # not a part of the object.Used for custom error patterns.
+        self.detail = getattr(error, 'detail', None)
 
     def as_problem_json(self):
         """Return problem+json of error message."""
@@ -65,6 +67,8 @@ class BusinessException(Exception):  # noqa
         problem_json = CodeService.find_code_value_by_type_and_code(Code.ERROR.value, self.code)
         if not problem_json:  # If the error is not configured in DB, return details from Error object
             problem_json = dict(type=self.code)
+            if self.detail:
+                problem_json['detail'] = self.detail
         return problem_json
 
     def response(self):

--- a/pay-api/src/pay_api/services/internal_pay_service.py
+++ b/pay-api/src/pay_api/services/internal_pay_service.py
@@ -133,9 +133,17 @@ class InternalPayService(PaymentSystemService, OAuthService):
             raise BusinessException(Error.RS_NOT_ACTIVE)
 
         if routing_slip.parent:
-            error = f'This Routing slip is linked, enter the parent Routing slip:{routing_slip.parent.number}'
-            raise BusinessException(type('obj', (object,), {'code': error, 'status': HTTPStatus.BAD_REQUEST})())
+            detail = f'This Routing slip is linked, enter the parent Routing slip:{routing_slip.parent.number}'
+            raise BusinessException(InternalPayService._create_error_object('LINKED_ROUTING_SLIP', detail))
         if routing_slip.remaining_amount < invoice.total:
-            error = f'There is not enough balance in this Routing slip. ' \
-                    f'The current balance is :${routing_slip.remaining_amount:.2f}'
-            raise BusinessException(type('obj', (object,), {'code': error, 'status': HTTPStatus.BAD_REQUEST})())
+            detail = f'There is not enough balance in this Routing slip. ' \
+                     f'The current balance is :${routing_slip.remaining_amount:.2f}'
+
+            raise BusinessException(InternalPayService.
+                                    _create_error_object('INSUFFICIENT_BALANCE_IN_ROUTING_SLIP', detail))
+
+    @staticmethod
+    def _create_error_object(code: str, detail: str):
+        return type('obj', (object,),
+                    {'code': code, 'status': HTTPStatus.BAD_REQUEST,
+                     'detail': detail})()

--- a/pay-api/tests/unit/api/test_payment_request.py
+++ b/pay-api/tests/unit/api/test_payment_request.py
@@ -367,8 +367,9 @@ def test_payment_creation_with_existing_invalid_routing_slip_invalid(client, jwt
 
     rv = client.post('/api/v1/payment-requests', data=json.dumps(data), headers=headers)
     assert rv.status_code == 400
-    assert 'There is not enough balance in this Routing slip' in rv.json.get('type')
-    assert f'${cheque_amount}.00' in rv.json.get('type')
+    assert 'There is not enough balance in this Routing slip' in rv.json.get('detail')
+    assert 'INSUFFICIENT_BALANCE_IN_ROUTING_SLIP' in rv.json.get('type')
+    assert f'${cheque_amount}.00' in rv.json.get('detail')
 
     # change status of routing slip to inactive
     rv = client.patch(f'/api/v1/fas/routing-slips/{rs_number}?action={PatchActions.UPDATE_STATUS.value}',
@@ -387,8 +388,9 @@ def test_payment_creation_with_existing_invalid_routing_slip_invalid(client, jwt
     client.post('/api/v1/fas/routing-slips/links', data=json.dumps(link_data), headers=headers)
     rv = client.post('/api/v1/payment-requests', data=json.dumps(data), headers=headers)
     assert rv.status_code == 400
-    assert 'This Routing slip is linked' in rv.json.get('type')
-    assert parent1.get('number') in rv.json.get('type')
+    assert 'LINKED_ROUTING_SLIP' in rv.json.get('type')
+    assert 'This Routing slip is linked' in rv.json.get('detail')
+    assert parent1.get('number') in rv.json.get('detail')
 
     # Flip the legacy routing slip flag
     data['accountInfo'] = {'routingSlip': 'invalid'}


### PR DESCRIPTION
*Description of changes:*

- Fixed currency formatting to match AC
- Changes to format the json to match the format` {‘type’: ‘LINKED_ROUTING_SLIP’, ‘detail’: ‘This Routing slip is linked, enter the parent Routing slip:12345’}`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
