### PR TITLE
Changes for allowing a sandbox account to be created by service account

### DIFF
--- a/pay-api/src/pay_api/resources/account.py
+++ b/pay-api/src/pay_api/resources/account.py
@@ -53,7 +53,7 @@ class Accounts(Resource):
         is_sandbox = request.args.get('sandbox', 'false').lower() == 'true'
         if is_sandbox and not _jwt.validate_roles([Role.CREATE_SANDBOX_ACCOUNT.value]):
             abort(HTTPStatus.FORBIDDEN)
-            
+
         # Validate the input request
         valid_format, errors = schema_utils.validate(request_json, 'account_info')
 

--- a/pay-api/src/pay_api/services/payment_account.py
+++ b/pay-api/src/pay_api/services/payment_account.py
@@ -313,7 +313,7 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
         return self._dao.flush()
 
     @classmethod
-    def create(cls, account_request: Dict[str, Any] = None) -> PaymentAccount:
+    def create(cls, account_request: Dict[str, Any] = None, is_sandbox: bool = False) -> PaymentAccount:
         """Create new payment account record."""
         current_app.logger.debug('<create payment account')
         auth_account_id = account_request.get('accountId')
@@ -323,7 +323,7 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
 
         account = PaymentAccountModel()
 
-        PaymentAccount._save_account(account_request, account)
+        PaymentAccount._save_account(account_request, account, is_sandbox)
         PaymentAccount._persist_default_statement_frequency(account.id)
 
         payment_account = PaymentAccount()
@@ -335,7 +335,8 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
         return payment_account
 
     @classmethod
-    def _save_account(cls, account_request: Dict[str, any], payment_account: PaymentAccountModel):
+    def _save_account(cls, account_request: Dict[str, any], payment_account: PaymentAccountModel,
+                      is_sandbox: bool = False):
         """Update and save payment account and CFS account model."""
         # pylint:disable=cyclic-import, import-outside-toplevel
         from pay_api.factory.payment_system_factory import PaymentSystemFactory
@@ -381,15 +382,9 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
             # If the account is PAD and bank details changed, then update bank details
             else:
                 # Update details in CFS
-                pay_system.update_account(name=payment_account.name, cfs_account=cfs_account,
-                                          payment_info=payment_info)
-            is_pad = payment_method == PaymentMethod.PAD.value
-            if is_pad:
-                # override payment method for since pad has 3 days wait period
-                effective_pay_method, activation_date = PaymentAccount._get_payment_based_on_pad_activation(
-                    payment_account)
-                payment_account.pad_activation_date = activation_date
-                payment_account.payment_method = effective_pay_method
+                pay_system.update_account(name=payment_account.name, cfs_account=cfs_account, payment_info=payment_info)
+
+            cls._update_pad_activation_date(cfs_account, is_sandbox, payment_account)
 
         elif pay_system.get_payment_system_code() == PaymentSystem.CGI.value:
             # if distribution code exists, put an end date as previous day and create new.
@@ -411,6 +406,22 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
                 cfs_account.status = CfsAccountStatus.INACTIVE.value
                 cfs_account.flush()
         payment_account.save()
+
+    @classmethod
+    def _update_pad_activation_date(cls, cfs_account: CfsAccountModel,
+                                    is_sandbox: bool, payment_account: PaymentAccountModel):
+        """Update PAD activation date."""
+        is_pad = payment_account.payment_method == PaymentMethod.PAD.value
+        # If the account is created for sandbox env, then set the status to ACTIVE and set pad activation time to now
+        if is_pad and is_sandbox:
+            cfs_account.status = CfsAccountStatus.ACTIVE.value
+            payment_account.pad_activation_date = datetime.now()
+        # override payment method for since pad has 3 days wait period
+        elif is_pad:
+            effective_pay_method, activation_date = PaymentAccount._get_payment_based_on_pad_activation(
+                payment_account)
+            payment_account.pad_activation_date = activation_date
+            payment_account.payment_method = effective_pay_method
 
     @classmethod
     def save_account_fees(cls, auth_account_id: str, account_fee_request: dict):

--- a/pay-api/src/pay_api/utils/enums.py
+++ b/pay-api/src/pay_api/utils/enums.py
@@ -114,6 +114,7 @@ class Role(Enum):
     VIEWER = 'view'
     EDITOR = 'edit'
     SYSTEM = 'system'
+    CREATE_SANDBOX_ACCOUNT = 'create_sandbox_account'
     MANAGE_GL_CODES = 'manage_gl_codes'
     PUBLIC_USER = 'public_user'
     EXCLUDE_SERVICE_FEES = 'exclude_service_fees'

--- a/pay-api/tests/unit/api/test_account.py
+++ b/pay-api/tests/unit/api/test_account.py
@@ -20,13 +20,14 @@ Test-Suite to ensure that the /accounts endpoint is working as expected.
 import json
 from unittest.mock import patch
 
+import pytest
 from requests.exceptions import ConnectionError
 
 from pay_api.exceptions import ServiceUnavailableException
 from pay_api.models.invoice import Invoice
 from pay_api.models.payment_account import PaymentAccount
 from pay_api.schemas import utils as schema_utils
-from pay_api.utils.enums import PaymentMethod, Role
+from pay_api.utils.enums import CfsAccountStatus, PaymentMethod, Role
 from tests.utilities.base_test import (
     get_basic_account_payload, get_claims, get_gov_account_payload, get_gov_account_payload_with_no_revenue_account,
     get_pad_account_payload, get_payment_request, get_premium_account_payload, get_unlinked_pad_account_payload,
@@ -549,3 +550,19 @@ def test_account_delete(session, client, jwt, app):
 
     rv = client.delete(f'/api/v1/accounts/{auth_account_id}', headers=headers)
     assert rv.status_code == 204
+
+
+@pytest.mark.parametrize('pay_load, is_cfs_account_expected', [
+    (get_unlinked_pad_account_payload(), True),
+    (get_premium_account_payload(), False)
+])
+def test_create_sandbox_accounts(session, client, jwt, app, pay_load, is_cfs_account_expected):
+    """Assert that the payment records are created with 202."""
+    token = jwt.create_jwt(get_claims(roles=[Role.SYSTEM.value, Role.CREATE_SANDBOX_ACCOUNT.value]), token_header)
+    headers = {'Authorization': f'Bearer {token}', 'content-type': 'application/json'}
+    rv = client.post('/api/v1/accounts?sandbox=true', data=json.dumps(pay_load),
+                     headers=headers)
+
+    assert rv.status_code == 201
+    if is_cfs_account_expected:
+        assert rv.json['cfsAccount']['status'] == CfsAccountStatus.ACTIVE.value


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/9800

*Description of changes:*
- Allow service account with create_sanbox_account role to allow creating sandbox accounts
- Set the sandbox account status to ACTIVE and set the PAD activation time to now


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
