### PR TITLE
Adjusting report API timeout to 360 seconds in gunicorn

### DIFF
--- a/report-api/Dockerfile
+++ b/report-api/Dockerfile
@@ -46,7 +46,7 @@ RUN python3 setup.py install
 EXPOSE 5001
 
 ENV NUM_WORKERS=3
-ENV TIMEOUT=120
+ENV TIMEOUT=360
 
 #CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--timeout", "$TIMEOUT", "--workers", "$NUM_WORKERS", "wsgi:app"]
-CMD gunicorn --bind 0.0.0.0:5001 --timeout $TIMEOUT --workers $NUM_WORKERS  wsgi:application
+CMD gunicorn --bind 0.0.0.0:5001 --timeout 360 --workers $NUM_WORKERS  wsgi:application

--- a/report-api/Dockerfile
+++ b/report-api/Dockerfile
@@ -49,4 +49,4 @@ ENV NUM_WORKERS=3
 ENV TIMEOUT=360
 
 #CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--timeout", "$TIMEOUT", "--workers", "$NUM_WORKERS", "wsgi:app"]
-CMD gunicorn --bind 0.0.0.0:5001 --timeout 360 --workers $NUM_WORKERS  wsgi:application
+CMD gunicorn --bind 0.0.0.0:5001 --timeout $TIMEOUT --workers $NUM_WORKERS  wsgi:application

--- a/report-api/entrypoint.sh
+++ b/report-api/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-echo "Waiting for postgres..."
+echo "starting application ..."
 
-gunicorn -b 0.0.0.0:5000 wsgi:application
+gunicorn -b 0.0.0.0:5000 wsgi:application --timeout 360


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
- Adjusting report API timeout to 360 seconds in gunicorn


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
