### PR TITLE
10068 - API validation for routing slip number length

### DIFF
--- a/pay-api/src/pay_api/schemas/schemas/routing_slip.json
+++ b/pay-api/src/pay_api/schemas/schemas/routing_slip.json
@@ -11,7 +11,9 @@
       "$id": "#/properties/number",
       "type": "string",
       "title": "Routing Slip Number",
-      "pattern": "^(.*)$"
+      "pattern": "^(.*)$",
+      "maxLength": 9,
+      "minLength": 9
     },
     "status": {
       "$id": "#/properties/status",

--- a/pay-api/tests/unit/api/fas/test_routing_slip.py
+++ b/pay-api/tests/unit/api/fas/test_routing_slip.py
@@ -587,3 +587,17 @@ def test_get_invalid_comments(client, jwt):
     rv = client.get('/api/v1/fas/routing-slips/{}/comments'.format('invalid'), headers=headers)
     assert rv.status_code == 400
     assert rv.json.get('type') == 'FAS_INVALID_ROUTING_SLIP_NUMBER'
+
+
+def test_create_routing_slips_invalid_number(client, jwt, app):
+    """Assert that the search works."""
+    token = jwt.create_jwt(get_claims(roles=[Role.FAS_CREATE.value, Role.FAS_SEARCH.value]), token_header)
+    headers = {'Authorization': f'Bearer {token}', 'content-type': 'application/json'}
+    payload = get_routing_slip_request(number='123456')
+    rv = client.post('/api/v1/fas/routing-slips', data=json.dumps(payload), headers=headers)
+    assert rv.status_code == 400
+    token = jwt.create_jwt(get_claims(roles=[Role.FAS_CREATE.value, Role.FAS_SEARCH.value]), token_header)
+    headers = {'Authorization': f'Bearer {token}', 'content-type': 'application/json'}
+    payload = get_routing_slip_request(number='1234567891')
+    rv = client.post('/api/v1/fas/routing-slips', data=json.dumps(payload), headers=headers)
+    assert rv.status_code == 400

--- a/pay-api/tests/unit/api/fas/test_routing_slip.py
+++ b/pay-api/tests/unit/api/fas/test_routing_slip.py
@@ -204,8 +204,8 @@ def test_link_routing_slip(client, jwt, app):
     assert rv.status_code == 400
 
     # assert transactions
-    child = get_routing_slip_request(number=fake.name())
-    parent = get_routing_slip_request(number=fake.name())
+    child = get_routing_slip_request(number='child2123')
+    parent = get_routing_slip_request(number='parent212')
     rv1 = client.post('/api/v1/fas/routing-slips', data=json.dumps(child), headers=headers)
     rv2 = client.post('/api/v1/fas/routing-slips', data=json.dumps(parent), headers=headers)
     payment_account_id = rv1.json.get('paymentAccount').get('id')
@@ -230,7 +230,7 @@ def test_link_routing_slip(client, jwt, app):
     assert rv.json.get('type') == 'RS_CHILD_HAS_TRANSACTIONS'
     assert rv.status_code == 400
 
-    child1 = get_routing_slip_request(number=fake.name())
+    child1 = get_routing_slip_request(number='child2999')
     client.post('/api/v1/fas/routing-slips', data=json.dumps(child1), headers=headers)
 
     data = {'childRoutingSlipNumber': f"{child1.get('number')}", 'parentRoutingSlipNumber': f"{child1.get('number')}"}

--- a/pay-api/tests/unit/api/fas/test_routing_slip.py
+++ b/pay-api/tests/unit/api/fas/test_routing_slip.py
@@ -137,9 +137,9 @@ def test_link_routing_slip_parent_is_a_child(client, jwt):
     token = jwt.create_jwt(get_claims(roles=[Role.FAS_CREATE.value, Role.FAS_LINK.value, Role.FAS_SEARCH.value]),
                            token_header)
     headers = {'Authorization': f'Bearer {token}', 'content-type': 'application/json'}
-    child = get_routing_slip_request()
-    parent1 = get_routing_slip_request(number=fake.name())
-    parent2 = get_routing_slip_request(number=fake.name())
+    child = get_routing_slip_request('456789123')
+    parent1 = get_routing_slip_request('123456789')
+    parent2 = get_routing_slip_request('987654321')
     client.post('/api/v1/fas/routing-slips', data=json.dumps(child), headers=headers)
     client.post('/api/v1/fas/routing-slips', data=json.dumps(parent1), headers=headers)
     client.post('/api/v1/fas/routing-slips', data=json.dumps(parent2), headers=headers)
@@ -163,8 +163,8 @@ def test_link_routing_slip(client, jwt, app):
     token = jwt.create_jwt(get_claims(roles=[Role.FAS_CREATE.value, Role.FAS_LINK.value, Role.FAS_SEARCH.value]),
                            token_header)
     headers = {'Authorization': f'Bearer {token}', 'content-type': 'application/json'}
-    child = get_routing_slip_request()
-    parent = get_routing_slip_request(number=fake.name())
+    child = get_routing_slip_request('123456789')
+    parent = get_routing_slip_request('abcdefghi')
     paid_amount_child = child.get('payments')[0].get('paidAmount')
     paid_amount_parent = parent.get('payments')[0].get('paidAmount')
     client.post('/api/v1/fas/routing-slips', data=json.dumps(child), headers=headers)
@@ -282,7 +282,7 @@ def test_create_routing_slips_search_with_folio_number(client, jwt, app):
 
     # create another routing slip with folo
 
-    payload = get_routing_slip_request(number='99999')
+    payload = get_routing_slip_request(number='999999999')
     rv = client.post('/api/v1/fas/routing-slips', data=json.dumps(payload), headers=headers)
     assert rv.status_code == 201
     payment_account_id = rv.json.get('paymentAccount').get('id')
@@ -351,7 +351,7 @@ def test_create_routing_slips_search_with_receipt(client, jwt, app):
     items = rv.json.get('items')
     assert len(items) == 0
 
-    payload = get_routing_slip_request(number='TEST',
+    payload = get_routing_slip_request(number='TEST12345',
                                        cheque_receipt_numbers=[('211001', PaymentMethod.CASH.value, 100)])
 
     rv = client.post('/api/v1/fas/routing-slips', data=json.dumps(payload), headers=headers)

--- a/pay-api/tests/unit/api/fas/test_routing_slip.py
+++ b/pay-api/tests/unit/api/fas/test_routing_slip.py
@@ -590,7 +590,7 @@ def test_get_invalid_comments(client, jwt):
 
 
 def test_create_routing_slips_invalid_number(client, jwt, app):
-    """Assert that the search works."""
+    """Assert that the rs number validation works."""
     token = jwt.create_jwt(get_claims(roles=[Role.FAS_CREATE.value, Role.FAS_SEARCH.value]), token_header)
     headers = {'Authorization': f'Bearer {token}', 'content-type': 'application/json'}
     payload = get_routing_slip_request(number='123456')

--- a/pay-api/tests/unit/api/test_payment_request.py
+++ b/pay-api/tests/unit/api/test_payment_request.py
@@ -377,7 +377,7 @@ def test_payment_creation_with_existing_invalid_routing_slip_invalid(client, jwt
     headers = {'Authorization': f'Bearer {token}', 'content-type': 'application/json'}
     # create an RS with less balance
     cheque_amount = 1
-    payload = get_routing_slip_request(cheque_receipt_numbers=[('1234567890',
+    payload = get_routing_slip_request(cheque_receipt_numbers=[('123456789',
                                                                 PaymentMethod.CHEQUE.value, cheque_amount)])
     rv = client.post('/api/v1/fas/routing-slips', data=json.dumps(payload), headers=headers)
     rs_number = rv.json.get('number')

--- a/pay-api/tests/unit/api/test_payment_request.py
+++ b/pay-api/tests/unit/api/test_payment_request.py
@@ -31,7 +31,7 @@ from pay_api.models import PaymentAccount as PaymentAccountModel
 from pay_api.schemas import utils as schema_utils
 from pay_api.utils.enums import InvoiceStatus, PatchActions, PaymentMethod, Role, RoutingSlipStatus
 from tests.utilities.base_test import (
-    activate_pad_account, fake, get_basic_account_payload, get_claims, get_gov_account_payload, get_payment_request,
+    activate_pad_account, get_basic_account_payload, get_claims, get_gov_account_payload, get_payment_request,
     get_payment_request_for_wills, get_payment_request_with_folio_number, get_payment_request_with_no_contact_info,
     get_payment_request_with_payment_method, get_payment_request_with_service_fees, get_payment_request_without_bn,
     get_premium_account_payload, get_routing_slip_request, get_unlinked_pad_account_payload,

--- a/pay-api/tests/unit/api/test_payment_request.py
+++ b/pay-api/tests/unit/api/test_payment_request.py
@@ -403,7 +403,7 @@ def test_payment_creation_with_existing_invalid_routing_slip_invalid(client, jwt
     assert rv.status_code == 400
     assert rv.json.get('type') == 'RS_NOT_ACTIVE'
 
-    parent1 = get_routing_slip_request(number=fake.name())
+    parent1 = get_routing_slip_request(number='child1234')
     client.post('/api/v1/fas/routing-slips', data=json.dumps(parent1), headers=headers)
     link_data = {'childRoutingSlipNumber': rs_number, 'parentRoutingSlipNumber': f"{parent1.get('number')}"}
     client.post('/api/v1/fas/routing-slips/links', data=json.dumps(link_data), headers=headers)

--- a/pay-api/tests/utilities/base_test.py
+++ b/pay-api/tests/utilities/base_test.py
@@ -691,7 +691,7 @@ def get_gov_account_payload_with_no_revenue_account(payment_method: str = Paymen
 
 
 def get_routing_slip_request(
-        number: str = '123456',
+        number: str = '123456789',
         cheque_receipt_numbers: List[Tuple] = [('1234567890', PaymentMethod.CHEQUE.value, 100)]
 ):
     """Return a routing slip request dictionary."""


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/10068
*Description of changes:*

- Update routingslip.json to add min and max legth for rs number
- test cases to validate


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
