### PR TITLE
Trying a GET on invoice, if invoice creation fails.

### DIFF
--- a/jobs/payment-jobs/tasks/cfs_create_invoice_task.py
+++ b/jobs/payment-jobs/tasks/cfs_create_invoice_task.py
@@ -248,17 +248,31 @@ class CreateInvoiceTask:  # pylint:disable=too-few-public-methods
             for invoice in account_invoices:
                 lines.extend(invoice.payment_line_items)
                 invoice_total += invoice.total
-
+            invoice_number = account_invoices[-1].id
             try:
                 # Get the first invoice id as the trx number for CFS
-                invoice_response = CFSService.create_account_invoice(transaction_number=account_invoices[-1].id,
+                invoice_response = CFSService.create_account_invoice(transaction_number=invoice_number,
                                                                      line_items=lines,
                                                                      cfs_account=cfs_account)
             except Exception as e:  # NOQA # pylint: disable=broad-except
-                capture_message(f'Error on creating PAD invoice: account id={payment_account.id}, '
-                                f'auth account : {payment_account.auth_account_id}, ERROR : {str(e)}', level='error')
-                current_app.logger.error(e)
-                continue
+                # There is a chance that the error is a timeout from CAS side,
+                # so to make sure we are not missing any data, make a GET call for the invoice we tried to create
+                # and use it if it got created.
+                has_invoice_created: bool = False
+                try:
+                    invoice_response = CFSService.get_invoice(cfs_account=cfs_account, inv_number=invoice_number)
+                    has_invoice_created = invoice_response.json().get('invoice_number', None) == invoice_number
+                except Exception as e:  # NOQA # pylint: disable=broad-except,unused-variable
+                    # Ignore this error, as it is irrelevant and error on outer level is relevant.
+                    pass
+                # If no invoice is created raise an error for sentry
+                if not has_invoice_created:
+                    capture_message(f'Error on creating PAD invoice: account id={payment_account.id}, '
+                                    f'auth account : {payment_account.auth_account_id}, ERROR : {str(e)}',
+                                    level='error')
+                    current_app.logger.error(e)
+                    continue
+
             # emit account mailer event
             mailer.publish_mailer_events('pad.invoiceCreated', payment_account, {'invoice_total': invoice_total})
             # Iterate invoice and create invoice reference records

--- a/jobs/payment-jobs/tasks/stale_payment_task.py
+++ b/jobs/payment-jobs/tasks/stale_payment_task.py
@@ -52,7 +52,7 @@ class StalePaymentTask:  # pylint: disable=too-few-public-methods
             except BusinessException as err:  # just catch and continue .Don't stop
                 # If the error is for COMPLETED PAYMENT, then mark the transaction as CANCELLED
                 # as there would be COMPLETED transaction in place and continue.
-                if err.code == Error.COMPLETED_PAYMENT.code:
+                if err.code == Error.COMPLETED_PAYMENT.name:
                     current_app.logger.info('Completed payment, marking transaction as CANCELLED.')
                     transaction.status_code = TransactionStatus.CANCELLED.value
                     transaction.save()

--- a/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
+++ b/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
@@ -489,7 +489,9 @@ def _get_payment_account(row) -> PaymentAccountModel:
         .join(CfsAccountModel, CfsAccountModel.account_id == PaymentAccountModel.id) \
         .filter(CfsAccountModel.cfs_account == account_number) \
         .filter(
-        CfsAccountModel.status.in_([CfsAccountStatus.ACTIVE.value, CfsAccountStatus.FREEZE.value])).one_or_none()
+        CfsAccountModel.status.in_(
+            [CfsAccountStatus.ACTIVE.value, CfsAccountStatus.FREEZE.value, CfsAccountStatus.INACTIVE.value]
+        )).one_or_none()
 
     return payment_account
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
- Try a GET on invoice is POST error-ed out, as it happened few times in PROD
- Adding INACTIVE cfs account as well during reconciliation, as an account changed from PAD to DRAWDOWN doesn't get reconciled
- Mark the transaction as CANCELLED, if there are no action required on the payment on stale payment job


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
