### PR TITLE
Changing NSF routing slip status to ACTIVE once linking is complete

### DIFF
--- a/jobs/payment-jobs/tasks/routing_slip_task.py
+++ b/jobs/payment-jobs/tasks/routing_slip_task.py
@@ -54,7 +54,6 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
             .filter(CfsAccountModel.status == CfsAccountStatus.ACTIVE.value).all()
 
         for routing_slip in routing_slips:
-
             # 1.reverse the child routing slip
             # 2.create receipt to the parent
             # 3.change the payment account of child to parent
@@ -73,13 +72,10 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
 
                 # apply receipt to parent cfs account
                 parent_rs: RoutingSlipModel = RoutingSlipModel.find_by_number(routing_slip.parent_number)
-
                 parent_payment_account: PaymentAccountModel = PaymentAccountModel.find_by_id(
                     parent_rs.payment_account_id)
-
                 parent_cfs_account: CfsAccountModel = CfsAccountModel.find_effective_by_account_id(
                     parent_payment_account.id)
-
                 # For linked routing slip receipts, append 'L' to the number to avoid duplicate error
                 receipt_number = f'{routing_slip.number}L'
                 CFSService.create_cfs_receipt(cfs_account=parent_cfs_account,
@@ -91,6 +87,8 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                 # Add to the list if parent is NSF, to apply the receipts.
                 if parent_rs.status == RoutingSlipStatus.NSF.value:
                     cls._apply_routing_slips_to_pending_invoices(parent_rs)
+                    # Update the parent routing slip status to ACTIVE
+                    parent_rs.status = RoutingSlipStatus.ACTIVE.value
 
                 routing_slip.save()
 

--- a/jobs/payment-jobs/tests/jobs/test_routing_slip_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_routing_slip_task.py
@@ -57,7 +57,7 @@ def test_link_rs(session):
     with patch('pay_api.services.CFSService.reverse_rs_receipt_in_cfs') as mock_cfs_reverse:
         with patch('pay_api.services.CFSService.create_cfs_receipt') as mock_create_cfs:
             RoutingSlipTask.link_routing_slips()
-            mock_cfs_reverse.assert_called
+            mock_cfs_reverse.assert_called()
             mock_cfs_reverse.assert_called_with(cfs_account, child_rs.number)
             mock_create_cfs.assert_called()
 
@@ -197,10 +197,13 @@ def test_link_to_nsf_rs(session):
     child_2_rs.save()
 
     # Run link process
-    RoutingSlipTask.link_routing_slips()
+    with patch('pay_api.services.CFSService.reverse_rs_receipt_in_cfs'):
+        RoutingSlipTask.link_routing_slips()
 
     # Now the invoice status should be PAID as RS has recovered.
     assert InvoiceModel.find_by_id(invoice.id).invoice_status_code == InvoiceStatus.PAID.value
+    # Parent Routing slip status should be ACTIVE now
+    assert RoutingSlipModel.find_by_number(parent_rs.number).status == RoutingSlipStatus.ACTIVE.value
 
 
 @pytest.mark.parametrize('rs_status', [


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/10414
https://github.com/bcgov/entity/issues/10413

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
