### PR TITLE
Calculate the account level service fee only if fee schedule got service fee configured.

### DIFF
--- a/jobs/payment-jobs/requirements.txt
+++ b/jobs/payment-jobs/requirements.txt
@@ -1,5 +1,5 @@
--e git+https://github.com/bcgov/sbc-common-components.git@d9b4616826f8dce6ec16540f24a88bfb530971c2#egg=sbc_common_components&subdirectory=python
--e git+https://github.com/bcgov/sbc-pay.git@4995411796dc637fa3452c34c7f91166e899ee8f#egg=pay_api&subdirectory=pay-api
+-e git+https://github.com/bcgov/sbc-common-components.git@41e4534eded37dbc7ff6763f91a8fd29a3faec21#egg=sbc_common_components&subdirectory=python
+-e git+https://github.com/bcgov/sbc-pay.git@3f917b42153eb6c52bbe63cec53dde76c7cc098f#egg=pay_api&subdirectory=pay-api
 Flask-Caching==1.10.1
 Flask-Migrate==2.7.0
 Flask-Moment==1.0.2
@@ -11,7 +11,7 @@ Jinja2==2.11.3
 Mako==1.1.6
 MarkupSafe==2.0.1
 PyNaCl==1.5.0
-SQLAlchemy-Continuum==1.3.11
+SQLAlchemy-Continuum==1.3.12
 SQLAlchemy-Utils==0.38.2
 SQLAlchemy==1.3.24
 Werkzeug==1.0.1
@@ -22,12 +22,12 @@ asyncio-nats-streaming==0.4.0
 attrs==21.4.0
 bcrypt==3.2.0
 blinker==1.4
-cachelib==0.5.0
+cachelib==0.6.0
 certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.10
 click==7.1.2
-croniter==1.1.0
+croniter==1.2.0
 cryptography==36.0.1
 dpath==2.0.5
 ecdsa==0.17.0
@@ -48,7 +48,7 @@ protobuf==3.19.3
 psycopg2-binary==2.9.3
 pyasn1==0.4.8
 pycparser==2.21
-pyrsistent==0.18.0
+pyrsistent==0.18.1
 pysftp==0.2.9
 python-dateutil==2.8.2
 python-dotenv==0.19.2

--- a/pay-api/src/pay_api/services/fee_schedule.py
+++ b/pay-api/src/pay_api/services/fee_schedule.py
@@ -355,7 +355,7 @@ class FeeSchedule:  # pylint: disable=too-many-public-methods, too-many-instance
         #  Handle it properly later
         if not user.is_staff() and \
                 not (user.is_system() and Role.EXCLUDE_SERVICE_FEES.value in user.roles) \
-                and fee_schedule_model.fee.amount > 0:
+                and fee_schedule_model.fee.amount > 0 and fee_schedule_model.service_fee:
             service_fee = (account_fee.service_fee if account_fee else None) or fee_schedule_model.service_fee
             if service_fee:
                 service_fees = FeeCodeModel.find_by_code(service_fee.code).amount


### PR DESCRIPTION

*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
- Calculate the account level service fee only if fee schedule got service fee configured.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
