### PR TITLE
Avoid duplicate entries and fix false alarm on reconciliations

### DIFF
--- a/queue_services/payment-reconciliations/requirements.txt
+++ b/queue_services/payment-reconciliations/requirements.txt
@@ -27,4 +27,4 @@ urllib3==1.26.7
 -e git+https://github.com/bcgov/lear.git#egg=entity_queue_common&subdirectory=queue_services/common
 -e git+https://github.com/bcgov/sbc-common-components.git#egg=sbc-common-components&subdirectory=python
 # -e git+https://github.com/bcgov/sbc-pay.git@refunds#egg=pay-api&subdirectory=pay-api
--e git+https://github.com/bcgov/sbc-pay.git@main#egg=pay-api&subdirectory=pay-api
+-e git+https://github.com/bcgov/sbc-pay.git@8d836db213914c9fef471a051bf42c8f25c97cb1#egg=pay-api&subdirectory=pay-api

--- a/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
+++ b/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
@@ -140,6 +140,12 @@ def _save_payment(payment_date, inv_number, invoice_amount,  # pylint: disable=t
         # pull out failed payment record if it exists and no COMPLETED payments are present.
         if not payment:
             payment = _get_payment_by_inv_number_and_status(inv_number, PaymentStatus.FAILED.value)
+    elif status == PaymentStatus.COMPLETED.value:
+        # if the payment status is COMPLETED, then make sure there are
+        # no other COMPLETED payment for same invoice_number.If found, return. This is to avoid duplicate entries.
+        payment = _get_payment_by_inv_number_and_status(inv_number, PaymentStatus.COMPLETED.value)
+        if payment:
+            return
 
     if not payment:
         payment = PaymentModel()
@@ -232,16 +238,18 @@ async def _process_consolidated_invoices(row):
         record_type = _get_row_value(row, Column.RECORD_TYPE)
         logger.debug('Processing invoice :  %s', inv_number)
 
-        inv_references: List[InvoiceReferenceModel] = db.session.query(InvoiceReferenceModel). \
-            filter(InvoiceReferenceModel.status_code == InvoiceReferenceStatus.ACTIVE.value). \
-            filter(InvoiceReferenceModel.invoice_number == inv_number). \
-            all()
+        inv_references = _find_invoice_reference_by_number_and_status(inv_number, InvoiceReferenceStatus.ACTIVE.value)
 
         payment_account: PaymentAccountModel = _get_payment_account(row)
 
         if target_txn_status.lower() == Status.PAID.value.lower():
             logger.debug('Fully PAID payment.')
-            if not inv_references:
+            # if no inv reference is found, and if there are no COMPLETED inv ref, raise alert
+            completed_inv_references = _find_invoice_reference_by_number_and_status(
+                inv_number, InvoiceReferenceStatus.COMPLETED.value
+            )
+
+            if not inv_references and not completed_inv_references:
                 logger.error('No invoice found for %s in the system, and cannot process %s.', inv_number, row)
                 capture_message(f'No invoice found for {inv_number} in the system, and cannot process {row}.',
                                 level='error')
@@ -259,6 +267,14 @@ async def _process_consolidated_invoices(row):
             logger.error('Target Transaction Type is received as %s for PAD, and cannot process %s.', target_txn, row)
             capture_message(
                 f'Target Transaction Type is received as {target_txn} for PAD, and cannot process.', level='error')
+
+
+def _find_invoice_reference_by_number_and_status(inv_number: str, status: str):
+    inv_references: List[InvoiceReferenceModel] = db.session.query(InvoiceReferenceModel). \
+        filter(InvoiceReferenceModel.status_code == status). \
+        filter(InvoiceReferenceModel.invoice_number == inv_number). \
+        all()
+    return inv_references
 
 
 async def _process_unconsolidated_invoices(row):


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
- Do not create duplicate COMPLETED payments for same invoice number
- Remove false alarm if same message is published again

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
