### PR TITLE
Skipping failed payment process if already exists to avoid duplicate …

### DIFF
--- a/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
+++ b/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
@@ -409,6 +409,14 @@ def _process_failed_payments(row):
     # 5. Create invoice reference for the newly created NSF invoice.
     # 6. Adjust invoice in CFS to include NSF fees.
     inv_number = _get_row_value(row, Column.TARGET_TXN_NO)
+    # If there is a FAILED payment record for this; it means it's a duplicate event. Ignore it.
+    payment: PaymentModel = PaymentModel.find_payment_by_invoice_number_and_status(
+        inv_number, PaymentStatus.FAILED.value
+    )
+    if payment:
+        logger.info('Ignoring duplicate NSF message for invoice : %s ', inv_number)
+        return
+
     # Set CFS Account Status.
     payment_account: PaymentAccountModel = _get_payment_account(row)
     cfs_account: CfsAccountModel = CfsAccountModel.find_effective_by_account_id(payment_account.id)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
- Skipping NSF process if the payment is already in a FAILED state

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
