### PR TITLE
11226 - FAS - Checksum for Routing Slip ID - Backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 develop-eggs/
+.pyenv/
 
 downloads/
 eggs/

--- a/pay-api/src/pay_api/services/fas/routing_slip.py
+++ b/pay-api/src/pay_api/services/fas/routing_slip.py
@@ -246,7 +246,8 @@ class RoutingSlip:  # pylint: disable=too-many-instance-attributes, too-many-pub
     @classmethod
     def validate_and_find_by_number(cls, rs_number: str) -> Dict[str, any]:
         """Validate digits before finding by routing slip number."""
-        RoutingSlip._validate_routing_slip_number_digits(rs_number)
+        if not current_app.config.get('ALLOW_LEGACY_ROUTING_SLIPS'):
+            RoutingSlip._validate_routing_slip_number_digits(rs_number)
         return cls.find_by_number(rs_number)
 
     @classmethod


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/11226

*Description of changes:*
Update .gitignore.
Small tweak to routing_slip.py to turn validation based off of: ALLOW_LEGACY_ROUTING_SLIPS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
