### PR TITLE
12019 - Fix failing CI workflows

### DIFF
--- a/pay-api/requirements.txt
+++ b/pay-api/requirements.txt
@@ -57,7 +57,6 @@ six==1.16.0
 threadloop==1.0.2
 thrift==0.16.0
 tornado==6.1
-typing_extensions==4.2.0
 urllib3==1.26.9
 zipp==3.8.0
 -e git+https://github.com/bcgov/sbc-common-components.git#egg=sbc-common-components&subdirectory=python

--- a/pay-api/requirements.txt
+++ b/pay-api/requirements.txt
@@ -21,9 +21,9 @@ cachelib==0.6.0
 certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.12
-click==8.1.0
+click==8.1.3
 croniter==1.3.4
-cryptography==36.0.2
+cryptography==37.0.1
 dpath==2.0.6
 ecdsa==0.17.0
 flask-jwt-oidc==0.3.0
@@ -32,7 +32,7 @@ flask-restx==0.5.1
 gunicorn==20.1.0
 idna==3.3
 importlib-metadata==4.11.3
-importlib-resources==5.6.0
+importlib-resources==5.7.1
 itsdangerous==2.0.1
 jaeger-client==4.8.0
 jsonschema==4.4.0
@@ -40,11 +40,11 @@ marshmallow-sqlalchemy==0.25.0
 marshmallow==3.15.0
 opentracing==2.4.0
 packaging==21.3
-protobuf==3.19.4
+protobuf==3.20.1
 psycopg2-binary==2.9.3
 pyasn1==0.4.8
 pycparser==2.21
-pyparsing==3.0.7
+pyparsing==3.0.8
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 python-dotenv==0.20.0
@@ -52,11 +52,12 @@ python-jose==3.3.0
 pytz==2022.1
 requests==2.27.1
 rsa==4.8
-sentry-sdk==1.5.8
+sentry-sdk==1.5.10
 six==1.16.0
 threadloop==1.0.2
-thrift==0.15.0
+thrift==0.16.0
 tornado==6.1
+typing_extensions==4.2.0
 urllib3==1.26.9
-zipp==3.7.0
+zipp==3.8.0
 -e git+https://github.com/bcgov/sbc-common-components.git#egg=sbc-common-components&subdirectory=python

--- a/queue_services/events-listener/requirements/prod.txt
+++ b/queue_services/events-listener/requirements/prod.txt
@@ -9,3 +9,4 @@ Werkzeug<2
 jaeger-client
 attrs
 itsdangerous==2.0.1
+Jinja2==3.0.3

--- a/queue_services/payment-reconciliations/requirements/prod.txt
+++ b/queue_services/payment-reconciliations/requirements/prod.txt
@@ -10,3 +10,4 @@ minio
 jaeger-client
 attrs
 sqlalchemy<1.4
+Jinja2==3.0.3

--- a/queue_services/payment-reconciliations/requirements/prod.txt
+++ b/queue_services/payment-reconciliations/requirements/prod.txt
@@ -10,4 +10,5 @@ minio
 jaeger-client
 attrs
 sqlalchemy<1.4
+itsdangerous==2.0.1
 Jinja2==3.0.3

--- a/queue_services/payment-reconciliations/tests/conftest.py
+++ b/queue_services/payment-reconciliations/tests/conftest.py
@@ -92,10 +92,14 @@ def db(app):  # pylint: disable=redefined-outer-name, invalid-name
 
         # even though this isn't referenced directly, it sets up the internal configs that upgrade
         import sys
-        pay_api_folder = [folder for folder in sys.path if 'pay-api' in folder][0]
-        migration_path = pay_api_folder.replace('/pay-api/src', '/pay-api/migrations')
+        migrations_path = [folder for folder in sys.path if 'pay-api/pay-api' in folder]
+        if len(migrations_path) > 0:
+            migrations_path = migrations_path[0].replace('/pay-api/src', '/pay-api/migrations')
+        # Fix for windows.
+        else:
+            migrations_path = os.path.abspath('../../pay-api/migrations')
 
-        Migrate(app, _db, directory=migration_path)
+        Migrate(app, _db, directory=migrations_path)
         upgrade()
 
         return _db

--- a/queue_services/payment-reconciliations/tests/docker-compose.yml
+++ b/queue_services/payment-reconciliations/tests/docker-compose.yml
@@ -14,12 +14,12 @@ services:
           - 8222:8222
         tty: true
     minio:
-        image: 'bitnami/minio:latest'
+        image: 'bitnami/minio:2022.4.26'
         ports:
           - '9000:9000'
         environment:
-          - MINIO_ACCESS_KEY=minio
-          - MINIO_SECRET_KEY=minio123
+          - MINIO_ROOT_USER=minio
+          - MINIO_ROOT_PASSWORD=minio123
           - MINIO_DEFAULT_BUCKETS=payment-sftp,test
 
     proxy:


### PR DESCRIPTION
*Description of changes:*
Pin Jinja 2 to 3.0.3. to fix the failing CI workflows.
Use a fixed version of Minio, use the new environment variables for it's secrets.
Fix the migration path for other operating systems.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
