### PR TITLE
11924 - Small fix for folioNumber, it's reading from the token but can be blank.

### DIFF
--- a/pay-api/src/pay_api/services/payment_service.py
+++ b/pay-api/src/pay_api/services/payment_service.py
@@ -98,8 +98,7 @@ class PaymentService:  # pylint: disable=too-few-public-methods
             invoice.routing_slip = get_str_by_path(account_info, 'routingSlip')
             invoice.filing_id = filing_info.get('filingIdentifier', None)
             invoice.dat_number = get_str_by_path(account_info, 'datNumber')
-            invoice.folio_number = filing_info.get('folioNumber',
-                                                   get_str_by_path(authorization, 'business/folioNumber'))
+            invoice.folio_number = filing_info.get('folioNumber', None)
             invoice.business_identifier = business_identifier
             invoice.payment_method_code = pay_service.get_payment_method_code()
             invoice.corp_type_code = corp_type

--- a/pay-api/tests/unit/api/test_payment_request.py
+++ b/pay-api/tests/unit/api/test_payment_request.py
@@ -603,7 +603,7 @@ def test_premium_payment_with_no_contact_info(session, client, jwt, app):
 
 @pytest.mark.parametrize('folio_number, payload', [
     ('1234567890', get_payment_request_with_folio_number(folio_number='1234567890')),
-    ('MOCK1234', get_payment_request())
+    ('', get_payment_request())
 ])
 def test_payment_creation_with_folio_number(session, client, jwt, app, folio_number, payload):
     """Assert that the endpoint returns 201."""

--- a/pay-api/tests/unit/api/test_payment_request.py
+++ b/pay-api/tests/unit/api/test_payment_request.py
@@ -603,7 +603,7 @@ def test_premium_payment_with_no_contact_info(session, client, jwt, app):
 
 @pytest.mark.parametrize('folio_number, payload', [
     ('1234567890', get_payment_request_with_folio_number(folio_number='1234567890')),
-    ('', get_payment_request())
+    (None, get_payment_request())
 ])
 def test_payment_creation_with_folio_number(session, client, jwt, app, folio_number, payload):
     """Assert that the endpoint returns 201."""


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/11924

*Description of changes:*
Remove folioNumber reading from auth token. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
