### PR TITLE
Minor tweak in notification.

### DIFF
--- a/jobs/payment-jobs/tasks/statement_notification_task.py
+++ b/jobs/payment-jobs/tasks/statement_notification_task.py
@@ -114,7 +114,7 @@ class StatementNotificationTask:  # pylint:disable=too-few-public-methods
         current_app.logger.info('send_email notify_response')
         if notify_response:
             response_json = json.loads(notify_response.text)
-            if response_json['notifyStatus']['code'] != 'FAILURE':
+            if response_json.get('notifyStatus', 'FAILURE') != 'FAILURE':
                 return True
 
         return False


### PR DESCRIPTION
This fixes:

```
2022-07-07 15:01:10,002 - invoke_jobs - INFO in statement_notification_task:statement_notification_task.py:114 - send_email: send_email notify_response
2022-07-07 15:01:10,002 - invoke_jobs - ERROR in statement_notification_task:statement_notification_task.py:84 - send_notifications: <notification failed
2022-07-07 15:01:10,006 - invoke_jobs - ERROR in statement_notification_task:statement_notification_task.py:85 - send_notifications: string indices must be integers
2022-07-07 15:01:10,009 - invoke_jobs - ERROR in statement_notification_task:statement_notification_task.py:89 - send_notifications: <notification failed
```
`"notifyStatus":"DELIVERED"`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
