### PR TITLE
Fix: unsupported operand type(s) for +: 'int' and 'NoneType'

### DIFF
--- a/pay-api/src/pay_api/services/payment_service.py
+++ b/pay-api/src/pay_api/services/payment_service.py
@@ -181,7 +181,7 @@ class PaymentService:  # pylint: disable=too-few-public-methods
                 invoice.paid = invoice.total
                 invoice.save()
             elif (payment_account.credit or 0) <= invoice_balance:
-                invoice.paid = (invoice.paid or 0) + payment_account.credit
+                invoice.paid = (invoice.paid or 0) + (payment_account.credit or 0)
                 invoice.save()
 
             payment_account.credit = credit_balance


### PR DESCRIPTION
Fix for: https://sentry.io/organizations/registries/issues/3411689127/?project=1762954 - payment_requests patch - unsupported operand type(s) for +: 'int' and 'NoneType'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
