### PR TITLE
Turn Sentry Off by using SENTRY_ENABLE FLAG instead of SENTRY_DSN#12422

### DIFF
--- a/bcol-api/devops/vaults.json
+++ b/bcol-api/devops/vaults.json
@@ -11,11 +11,16 @@
             "bcol"
         ]
     },
-    {
+	{
         "vault": "relationship",
-        "application": [
-            "sentry",
+        "application": [            
             "jwt"
+        ]
+    },
+	{
+        "vault": "sentry",
+        "application": [
+            "relationship-api"
         ]
     }
 ]

--- a/bcol-api/docs/dotenv_template
+++ b/bcol-api/docs/dotenv_template
@@ -16,6 +16,7 @@ SQLALCHEMY_ECHO=False
 # The sentry.io Data Source Name for the project. For local development this should always be blank, to prevent the
 # logging (and emailing) of errors. However it can be temporarily set when working with sentry itself.
 #
+SENTRY_ENABLE=false
 SENTRY_DSN=
 
 # keycloak settings

--- a/bcol-api/requirements/prod.txt
+++ b/bcol-api/requirements/prod.txt
@@ -16,3 +16,4 @@ Werkzeug<2
 jaeger-client
 pycountry
 itsdangerous==2.0.1
+Jinja2==3.0.3

--- a/bcol-api/setup.cfg
+++ b/bcol-api/setup.cfg
@@ -65,12 +65,23 @@ good-names=
 
 [pylint]
 ignore=migrations,test
-max_line_length=120
+max-line-length=120
 notes=FIXME,XXX,TODO
 ignored-modules=flask_sqlalchemy,sqlalchemy,SQLAlchemy,alembic,scoped_session
 ignored-classes=scoped_session
 min-similarity-lines=8
 disable=C0301,W0511,R0801,R0902
+good-names=
+    b,
+    d,
+    i,
+    e,
+    f,
+    u,
+    rv,
+    logger,
+    id,
+    p,
 
 [isort]
 line_length = 120

--- a/bcol-api/src/bcol_api/__init__.py
+++ b/bcol-api/src/bcol_api/__init__.py
@@ -41,11 +41,12 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     app.config.from_object(config.CONFIGURATION[run_mode])
 
     # Configure Sentry
-    if app.config.get('SENTRY_DSN', None):
-        sentry_sdk.init(
-            dsn=app.config.get('SENTRY_DSN'),
-            integrations=[FlaskIntegration()]
-        )
+    if str(app.config.get('SENTRY_ENABLE')).lower() == 'true':
+        if app.config.get('SENTRY_DSN', None):
+            sentry_sdk.init(
+                dsn=app.config.get('SENTRY_DSN'),
+                integrations=[FlaskIntegration()]
+            )
 
     app.register_blueprint(API_BLUEPRINT)
     app.register_blueprint(OPS_BLUEPRINT)

--- a/bcol-api/src/bcol_api/config.py
+++ b/bcol-api/src/bcol_api/config.py
@@ -94,6 +94,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     BCOL_APPLIED_CHARGE_WSDL_URL = _get_config('BCOL_APPLIED_CHARGE_WSDL_URL')
 
     # Sentry Config
+    SENTRY_ENABLE = _get_config('SENTRY_ENABLE', default=False)
     SENTRY_DSN = _get_config('SENTRY_DSN', default=None)
 
     TESTING = False

--- a/bcol-api/src/bcol_api/services/bcol_payment.py
+++ b/bcol-api/src/bcol_api/services/bcol_payment.py
@@ -90,23 +90,23 @@ class BcolPayment:  # pylint:disable=too-few-public-methods
         current_app.logger.debug('>query_profile')
         return pay_response
 
-    def __get(self, value: object, key: object) -> str:  # pragma: no cover # pylint: disable=no-self-use
+    def __get(self, value: object, key: object) -> str:  # pragma: no cover
         """Get the value from dict and strip."""
         if value and value[key]:
             return value[key].strip() if isinstance(value[key], str) else value[key]
         return None
 
-    def debit_account(self, data: Dict):  # pragma: no cover # pylint: disable=no-self-use
+    def debit_account(self, data: Dict):  # pragma: no cover
         """Debit BCOL account."""
         client = BcolSoap().get_payment_client()
         return zeep.helpers.serialize_object(client.service.debitAccount(req=data))
 
-    def apply_charge(self, data: Dict):  # pragma: no cover # pylint: disable=no-self-use
+    def apply_charge(self, data: Dict):  # pragma: no cover
         """Debit BCOL account as a staff user."""
         client = BcolSoap().get_applied_chg_client()
         return zeep.helpers.serialize_object(client.service.appliedCharge(req=data))
 
-    def _pad_zeros(self, amount: str = '0'):  # pylint: disable=no-self-use
+    def _pad_zeros(self, amount: str = '0'):
         """Pad the amount with Zeroes to make sure the string is 10 chars."""
         if not amount:
             return None

--- a/bcol-api/src/bcol_api/services/bcol_profile.py
+++ b/bcol-api/src/bcol_api/services/bcol_profile.py
@@ -113,7 +113,7 @@ class BcolProfile:  # pylint:disable=too-few-public-methods
             raise BusinessException(Error.SYSTEM_ERROR) from e
         return response
 
-    def __authenticate_user(self, user_id: str, password: str) -> bool:  # pylint: disable=no-self-use
+    def __authenticate_user(self, user_id: str, password: str) -> bool:
         """Validate the user by ldap lookup."""
         current_app.logger.debug('<<< _validate_user')
         ldap_conn = None
@@ -124,7 +124,7 @@ class BcolProfile:  # pylint:disable=too-few-public-methods
             )
             ldap_conn.set_option(ldap.OPT_REFERRALS, 0)  # pylint: disable=no-member
             ldap_conn.set_option(ldap.OPT_PROTOCOL_VERSION, 3)  # pylint: disable=no-member
-            ldap_conn.set_option(ldap.OPT_X_TLS, ldap.OPT_X_TLS_DEMAND)  # pylint: disable=no-member
+            # ldap_conn.set_option(ldap.OPT_X_TLS, ldap.OPT_X_TLS_DEMAND)  # pylint: disable=no-member
             ldap_conn.set_option(ldap.OPT_X_TLS_DEMAND, True)  # pylint: disable=no-member
             ldap_conn.set_option(ldap.OPT_DEBUG_LEVEL, 255)  # pylint: disable=no-member
 
@@ -141,13 +141,13 @@ class BcolProfile:  # pylint:disable=too-few-public-methods
 
         current_app.logger.debug('>>> _validate_user')
 
-    def __get(self, value: object, key: object) -> str:  # pylint: disable=no-self-use
+    def __get(self, value: object, key: object) -> str:
         """Get the value from dict and strip."""
         if value and value[key]:
             return value[key].strip() if isinstance(value[key], str) else value[key]
         return None
 
-    def get_profile_response(self, data: Dict):  # pragma: no cover # pylint: disable=no-self-use
+    def get_profile_response(self, data: Dict):  # pragma: no cover
         """Get Query Profile Response."""
         client = BcolSoap().get_profile_client()
         return zeep.helpers.serialize_object(client.service.queryProfile(req=data))

--- a/jobs/ftp-poller/config.py
+++ b/jobs/ftp-poller/config.py
@@ -121,6 +121,9 @@ class _Config(object):  # pylint: disable=too-few-public-methods
     MINIO_CGI_BUCKET_NAME = os.getenv('MINIO_CGI_BUCKET_NAME', 'cgi-ejv')
     MINIO_SECURE = True
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
+    SENTRY_DSN = os.getenv('SENTRY_DSN', None)
+
     TESTING = False
     DEBUG = True
 

--- a/jobs/ftp-poller/devops/vaults.json
+++ b/jobs/ftp-poller/devops/vaults.json
@@ -14,11 +14,17 @@
             "payment-reconciliations"
         ]
     },
-    {
+	{
         "vault": "relationship",
         "application": [
             "postgres-pay",
             "ftp-poller"
+        ]
+    },
+	{
+        "vault": "sentry",
+        "application": [
+            "relationship-api"
         ]
     }
 ]

--- a/jobs/ftp-poller/invoke_jobs.py
+++ b/jobs/ftp-poller/invoke_jobs.py
@@ -37,11 +37,12 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
 
     app.config.from_object(config.CONFIGURATION[run_mode])
     # Configure Sentry
-    if app.config.get('SENTRY_DSN', None):  # pragma: no cover
-        sentry_sdk.init(
-            dsn=app.config.get('SENTRY_DSN'),
-            integrations=[FlaskIntegration()]
-        )
+    if str(app.config.get('SENTRY_ENABLE')).lower() == 'true':
+        if app.config.get('SENTRY_DSN', None):
+            sentry_sdk.init(
+                dsn=app.config.get('SENTRY_DSN'),
+                integrations=[FlaskIntegration()]
+            )
     app.logger.info(f'<<<< Starting Ftp Poller Job >>>>')
     db.init_app(app)
     ma.init_app(app)

--- a/jobs/ftp-poller/setup.cfg
+++ b/jobs/ftp-poller/setup.cfg
@@ -42,7 +42,7 @@ per-file-ignores =
     */__init__.py:F401
 
 [pycodestyle]
-max_line_length = 120
+max-line-length = 120
 ignore = E501
 docstring-min-length=10
 notes=FIXME,XXX # TODO is ignored
@@ -57,20 +57,39 @@ good-names=
     i,
     e,
     f,
+    k,
+    q,
     u,
+    v,
+    ar,
+    id,
     rv,
     logger,
-    id,
-    p,
 
 [pylint]
 ignore=migrations,test
-max_line_length=120
+max-line-length=120
 notes=FIXME,XXX,TODO
 ignored-modules=flask_sqlalchemy,sqlalchemy,SQLAlchemy,alembic,scoped_session
 ignored-classes=scoped_session
 min-similarity-lines=8
 disable=C0301,W0511
+
+good-names=
+    b,
+    d,
+    i,
+    e,
+    f,
+    k,
+    q,
+    u,
+    v,
+    ar,
+    id,
+    rv,
+    logger,
+
 
 [isort]
 line_length = 120

--- a/jobs/payment-jobs/config.py
+++ b/jobs/payment-jobs/config.py
@@ -127,6 +127,7 @@ class _Config(object):  # pylint: disable=too-few-public-methods
     CFS_INVOICE_CUT_OFF_HOURS_UTC = int(os.getenv('CFS_INVOICE_CUT_OFF_HOURS_UTC', '2'))
     CFS_INVOICE_CUT_OFF_MINUTES_UTC = int(os.getenv('CFS_INVOICE_CUT_OFF_MINUTES_UTC', '0'))
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
 
     # The number of characters which can be exposed to admins for a bank account number

--- a/jobs/payment-jobs/devops/vaults.json
+++ b/jobs/payment-jobs/devops/vaults.json
@@ -28,15 +28,20 @@
             "cfs"
         ]
     },
-    {
+	{
         "vault": "relationship",
         "application": [
             "postgres-pay",
             "pay-api",
-            "sentry",
             "jwt",
             "payment-jobs",
             "ftp-poller"
+        ]
+    },
+	{
+        "vault": "sentry",
+        "application": [
+            "relationship-api"
         ]
     },
     {

--- a/jobs/payment-jobs/invoke_jobs.py
+++ b/jobs/payment-jobs/invoke_jobs.py
@@ -38,11 +38,12 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
 
     app.config.from_object(config.CONFIGURATION[run_mode])
     # Configure Sentry
-    if app.config.get('SENTRY_DSN', None):  # pragma: no cover
-        sentry_sdk.init(
-            dsn=app.config.get('SENTRY_DSN'),
-            integrations=[FlaskIntegration()]
-        )
+    if str(app.config.get('SENTRY_ENABLE')).lower() == 'true':
+        if app.config.get('SENTRY_DSN', None):
+            sentry_sdk.init(
+                dsn=app.config.get('SENTRY_DSN'),
+                integrations=[FlaskIntegration()]
+            )
     app.logger.info(f'<<<< Starting Payment Jobs >>>>')
     db.init_app(app)
     ma.init_app(app)

--- a/jobs/payment-jobs/tasks/cfs_bank_name_updater.py
+++ b/jobs/payment-jobs/tasks/cfs_bank_name_updater.py
@@ -43,11 +43,12 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
 
     app.config.from_object(config.CONFIGURATION[run_mode])
     # Configure Sentry
-    if app.config.get('SENTRY_DSN', None):  # pragma: no cover
-        sentry_sdk.init(
-            dsn=app.config.get('SENTRY_DSN'),
-            integrations=[FlaskIntegration()]
-        )
+    if str(app.config.get('SENTRY_ENABLE')).lower() == 'true':
+        if app.config.get('SENTRY_DSN', None):
+            sentry_sdk.init(
+                dsn=app.config.get('SENTRY_DSN'),
+                integrations=[FlaskIntegration()]
+            )
     db.init_app(app)
     ma.init_app(app)
 

--- a/pay-admin/devops/vaults.json
+++ b/pay-admin/devops/vaults.json
@@ -5,5 +5,11 @@
       "postgres-pay",
       "pay-admin"
     ]
+  },
+  {
+	"vault": "sentry",
+	"application": [
+		"relationship-api"
+	]
   }
 ]

--- a/pay-api/devops/vaults.json
+++ b/pay-api/devops/vaults.json
@@ -29,13 +29,18 @@
             "cfs"
         ]
     },
-    {
+	{
         "vault": "relationship",
         "application": [
             "postgres-pay",
             "pay-api",
-            "sentry",
             "jwt"
+        ]
+    },
+	{
+        "vault": "sentry",
+        "application": [
+            "relationship-api"
         ]
     }
 ]

--- a/pay-api/docs/dotenv_template
+++ b/pay-api/docs/dotenv_template
@@ -32,6 +32,7 @@ SQLALCHEMY_ECHO=False
 # The sentry.io Data Source Name for the project. For local development this should always be blank, to prevent the
 # logging (and emailing) of errors. However it can be temporarily set when working with sentry itself.
 #
+SENTRY_ENABLE=false
 SENTRY_DSN=
 
 # keycloak settings

--- a/pay-api/src/pay_api/__init__.py
+++ b/pay-api/src/pay_api/__init__.py
@@ -48,11 +48,12 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     if run_mode != 'migration':
 
         # Configure Sentry
-        if app.config.get('SENTRY_DSN', None):  # pragma: no cover
-            sentry_sdk.init(  # pylint: disable=abstract-class-instantiated
-                dsn=app.config.get('SENTRY_DSN'),
-                integrations=[FlaskIntegration()]
-            )
+        if str(app.config.get('SENTRY_ENABLE')).lower() == 'true':
+            if app.config.get('SENTRY_DSN', None):  # pragma: no cover
+                sentry_sdk.init(  # pylint: disable=abstract-class-instantiated
+                    dsn=app.config.get('SENTRY_DSN'),
+                    integrations=[FlaskIntegration()]
+                )
         # pylint: disable=import-outside-toplevel
         from pay_api.resources import API_BLUEPRINT, OPS_BLUEPRINT
 

--- a/pay-api/src/pay_api/config.py
+++ b/pay-api/src/pay_api/config.py
@@ -137,6 +137,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     BCOL_API_ENDPOINT = _get_config('BCOL_API_URL')
 
     # Sentry Config
+    SENTRY_ENABLE = _get_config('SENTRY_ENABLE', default=False)
     SENTRY_DSN = _get_config('SENTRY_DSN', default=None)
 
     # Valid Payment redirect URLs

--- a/queue_services/events-listener/devops/vaults.json
+++ b/queue_services/events-listener/devops/vaults.json
@@ -6,11 +6,17 @@
             "entity-events-listener"
         ]
     },
-    {
+	{
         "vault": "relationship",
         "application": [
             "postgres-pay",
             "jwt"
+        ]
+    },
+	{
+        "vault": "sentry",
+        "application": [
+            "relationship-api"
         ]
     }
 ]

--- a/queue_services/events-listener/src/events_listener/config.py
+++ b/queue_services/events-listener/src/events_listener/config.py
@@ -60,6 +60,7 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/queue_services/payment-reconciliations/devops/vaults.json
+++ b/queue_services/payment-reconciliations/devops/vaults.json
@@ -28,11 +28,16 @@
             "cfs"
         ]
     },
-    {
+	{
         "vault": "relationship",
         "application": [
-            "postgres-pay",
-            "sentry"
+            "postgres-pay"
+        ]
+    },
+	{
+        "vault": "sentry",
+        "application": [
+            "relationship-api"
         ]
     }
 ]

--- a/queue_services/payment-reconciliations/src/reconciliations/config.py
+++ b/queue_services/payment-reconciliations/src/reconciliations/config.py
@@ -60,6 +60,7 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/report-api/setup.cfg
+++ b/report-api/setup.cfg
@@ -63,11 +63,20 @@ good-names=
 
 [pylint]
 ignore=migrations,test
-max_line_length=120
+max-line-length=120
 notes=FIXME,XXX,TODO
 ignored-modules=flask_sqlalchemy,sqlalchemy,SQLAlchemy,alembic,scoped_session
 ignored-classes=scoped_session
 disable=C0301,W0511
+good-names=
+    b,
+    d,
+    i,
+    e,
+    f,
+    u,
+    rv,
+    logger,
 
 [isort]
 line_length = 120

--- a/report-api/src/api/__init__.py
+++ b/report-api/src/api/__init__.py
@@ -36,7 +36,7 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     app.config.from_object(config.CONFIGURATION[run_mode])  # pylint: disable=no-member
 
     # Configure Sentry
-    if app.config.get('SENTRY_ENABLE') == 'True':
+    if str(app.config.get('SENTRY_ENABLE')).lower() == 'true':
         if app.config.get('SENTRY_DSN', None):
             sentry_sdk.init(
                 dsn=app.config.get('SENTRY_DSN'),


### PR DESCRIPTION
Signed-off-by: Chen <Steven.Chen@gov.bc.ca>

*Issue #:*
https://github.com/bcgov/entity/issues/12422

*Description of changes:*
Turn Sentry Off by using SENTRY_ENABLE FLAG instead of SENTRY_DSN

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
