### PR TITLE
Fix to skip over AP_REFUNDS for now (they all fail) (#972)

### DIFF
--- a/.github/workflows/payment-reconciliations-ci.yml
+++ b/.github/workflows/payment-reconciliations-ci.yml
@@ -66,6 +66,7 @@ jobs:
       CFS_CLIENT_ID: "TEST"
       CFS_CLIENT_SECRET: "TEST"
       ACCOUNT_SECRET_KEY: "abcdefg"
+      DISABLE_AP_FEEDBACK: False
 
     runs-on: ubuntu-20.04
 

--- a/queue_services/events-listener/requirements/dev.txt
+++ b/queue_services/events-listener/requirements/dev.txt
@@ -27,5 +27,5 @@ isort
 
 # docker
 lovely-pytest-docker
-pytest-asyncio
+pytest-asyncio==0.18.3
 

--- a/queue_services/payment-reconciliations/src/reconciliations/cgi_reconciliations.py
+++ b/queue_services/payment-reconciliations/src/reconciliations/cgi_reconciliations.py
@@ -96,7 +96,9 @@ async def _update_feedback(msg: Dict[str, any]):  # pylint:disable=too-many-loca
     content = file.data.decode('utf-8-sig')
     group_batches: List[str] = _group_batches(content)
     has_errors = await _process_ejv_feedback(group_batches['EJV'])
-    has_errors = await _process_ap_feedback(group_batches['AP']) or has_errors
+
+    if not APP_CONFIG.DISABLE_AP_FEEDBACK:
+        has_errors = await _process_ap_feedback(group_batches['AP']) or has_errors
 
     if has_errors and not APP_CONFIG.DISABLE_EJV_ERROR_EMAIL:
         await _publish_mailer_events(file_name, minio_location)

--- a/queue_services/payment-reconciliations/src/reconciliations/config.py
+++ b/queue_services/payment-reconciliations/src/reconciliations/config.py
@@ -117,6 +117,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     # Disable EJV Error Email
     DISABLE_EJV_ERROR_EMAIL = os.getenv('DISABLE_EJV_ERROR_EMAIL', 'true').lower() == 'true'
+    # Disable AP Feedback processing
+    DISABLE_AP_FEEDBACK = os.getenv('DISABLE_AP_FEEDBACK', 'true').lower() == 'true'
 
 
 class DevConfig(_Config):  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
* Fix to skip over AP_REFUNDS for now (they all fail)

* Update workflows.

*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
