### PR TITLE
Changes for BCOL_Service to allow override for staff fee code

### DIFF
--- a/pay-api/src/pay_api/services/bcol_service.py
+++ b/pay-api/src/pay_api/services/bcol_service.py
@@ -52,6 +52,7 @@ class BcolService(PaymentSystemService, OAuthService):
         current_app.logger.debug(f'<Creating BCOL records for Invoice: {invoice.id}, '
                                  f'Auth Account : {payment_account.auth_account_id}')
         user: UserContext = kwargs['user']
+        force_non_staff_fee_code = kwargs['force_non_staff_fee_code']
         pay_endpoint = current_app.config.get('BCOL_API_ENDPOINT') + '/payments'
         invoice_number = generate_transaction_number(invoice.id)
         corp_number = invoice.business_identifier or ''
@@ -61,7 +62,7 @@ class BcolService(PaymentSystemService, OAuthService):
         if user.first_name:
             remarks = f'{remarks}-{user.first_name}'
 
-        use_staff_fee_code = (user.is_staff() or user.is_system())
+        use_staff_fee_code = (user.is_staff() or user.is_system()) and force_non_staff_fee_code is None
         # CSO currently refunds an invoice, and creates a new invoice for partial refunds.
         # This only applies for CSBPDOC. CSO only uses a single PLI per invoice.
         if filing_types == 'CSBPDOC':


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/14010

*Description of changes:*
Changes to allow overriding staff bcol fee code. This way we can reuse the code from a jupyter notebook to recreate BCOL transactions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
