### PR TITLE
14346 - Routing slip job reverse throwing error fixing

### DIFF
--- a/jobs/payment-jobs/tasks/routing_slip_task.py
+++ b/jobs/payment-jobs/tasks/routing_slip_task.py
@@ -31,8 +31,8 @@ from pay_api.models import db
 from pay_api.services.cfs_service import CFSService
 from pay_api.services.receipt import Receipt
 from pay_api.utils.enums import (
-    CfsAccountStatus, InvoiceReferenceStatus, InvoiceStatus, LineItemStatus, PaymentMethod, PaymentStatus,
-    ReverseOperation, RoutingSlipStatus)
+    CfsAccountStatus, CfsReceiptStatus, InvoiceReferenceStatus, InvoiceStatus, LineItemStatus, PaymentMethod,
+    PaymentStatus, ReverseOperation, RoutingSlipStatus)
 from sentry_sdk import capture_message
 
 
@@ -66,7 +66,8 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                     payment_account.id)
 
                 # reverse routing slip receipt
-                CFSService.reverse_rs_receipt_in_cfs(cfs_account, routing_slip.number, ReverseOperation.LINK.value)
+                if CFSService.get_receipt(cfs_account, routing_slip.number).get('status') != CfsReceiptStatus.REV.value:
+                    CFSService.reverse_rs_receipt_in_cfs(cfs_account, routing_slip.number, ReverseOperation.LINK.value)
                 cfs_account.status = CfsAccountStatus.INACTIVE.value
 
                 # apply receipt to parent cfs account

--- a/jobs/payment-jobs/tests/jobs/test_routing_slip_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_routing_slip_task.py
@@ -27,9 +27,11 @@ from pay_api.models import PaymentAccount as PaymentAccountModel
 from pay_api.models import Receipt as ReceiptModel
 from pay_api.models import RoutingSlip as RoutingSlipModel
 from pay_api.utils.enums import (
-    CfsAccountStatus, InvoiceReferenceStatus, InvoiceStatus, PaymentMethod, ReverseOperation, RoutingSlipStatus)
+    CfsAccountStatus, InvoiceReferenceStatus, InvoiceStatus,
+    PaymentMethod, ReverseOperation, RoutingSlipStatus)
 
 from tasks.routing_slip_task import RoutingSlipTask
+from pay_api.services import CFSService
 
 from .factory import (
     factory_distribution, factory_distribution_link, factory_invoice, factory_invoice_reference,
@@ -56,10 +58,12 @@ def test_link_rs(session):
 
     with patch('pay_api.services.CFSService.reverse_rs_receipt_in_cfs') as mock_cfs_reverse:
         with patch('pay_api.services.CFSService.create_cfs_receipt') as mock_create_cfs:
-            RoutingSlipTask.link_routing_slips()
-            mock_cfs_reverse.assert_called()
-            mock_cfs_reverse.assert_called_with(cfs_account, child_rs.number, ReverseOperation.LINK.value)
-            mock_create_cfs.assert_called()
+            with patch.object(CFSService, 'get_receipt') as mock_get_receipt:
+                RoutingSlipTask.link_routing_slips()
+                mock_cfs_reverse.assert_called()
+                mock_cfs_reverse.assert_called_with(cfs_account, child_rs.number, ReverseOperation.LINK.value)
+                mock_create_cfs.assert_called()
+                mock_get_receipt.assert_called()
 
     # child_rs = RoutingSlipModel.find_by_number(child_rs_number)
     # parent_rs = RoutingSlipModel.find_by_number(parent_rs_number)

--- a/pay-api/src/pay_api/utils/enums.py
+++ b/pay-api/src/pay_api/utils/enums.py
@@ -282,3 +282,7 @@ class ReverseOperation(Enum):
     LINK = 'LINK'
     VOID = 'VOID'
     CORRECTION = 'CORRECTION'
+
+
+class CfsReceiptStatus(Enum):
+    REV = 'REV'


### PR DESCRIPTION
*Issue #14346:*
https://github.com/bcgov/entity/issues/14346

*Description of changes:*

I added a receipt status check before send reverse request to cfs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
