### PR TITLE
12777 - System Exit 1 / Performance fixes for Invoice searching, also statement building

### DIFF
--- a/pay-api/migrations/versions/39c2491d0a07_migration_for_business_details.py
+++ b/pay-api/migrations/versions/39c2491d0a07_migration_for_business_details.py
@@ -1,0 +1,26 @@
+"""Update details to include the label + business identifier.
+
+Revision ID: 39c2491d0a07
+Revises: fd5c02bb9e01
+Create Date: 2023-01-12 15:24:43.729871
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '39c2491d0a07'
+down_revision = 'fd5c02bb9e01'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("update invoices set details = json_build_array(json_build_object('key', 'Registration Number:', 'value', business_identifier)) where (corp_type_code = 'SP' or corp_type_code = 'GP') and details = 'null' and business_identifier is not null")
+    op.execute("update invoices set details = json_build_array(json_build_object('key', 'Incorporation Number:', 'value', business_identifier)) where corp_type_code in (select code from corp_types where product = 'BUSINESS' and code <> 'NRO') and details = 'null' and business_identifier is not null")
+    pass
+
+
+def downgrade():
+    pass

--- a/pay-api/src/pay_api/models/invoice.py
+++ b/pay-api/src/pay_api/models/invoice.py
@@ -22,19 +22,15 @@ from sqlalchemy import ForeignKey
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
-from pay_api.utils.constants import INCORPORATION_LABEL, REGISTRATION_LABEL
-from pay_api.utils.enums import CorpType as CorpTypeEnum
-from pay_api.utils.enums import (
-    InvoiceReferenceStatus, InvoiceStatus, LineItemStatus, PaymentMethod, PaymentStatus, Product)
+from pay_api.utils.enums import InvoiceReferenceStatus, InvoiceStatus, LineItemStatus, PaymentMethod, PaymentStatus
 
 from .audit import Audit, AuditSchema
 from .base_schema import BaseSchema
-from .corp_type import CorpType
 from .db import db, ma
 from .invoice_reference import InvoiceReferenceSchema
+from .payment_account import PaymentAccountSchema
 from .payment_line_item import PaymentLineItem, PaymentLineItemSchema
 from .receipt import ReceiptSchema
-from .payment_account import PaymentAccountSchema
 
 
 class Invoice(Audit):  # pylint: disable=too-many-instance-attributes
@@ -175,15 +171,4 @@ class InvoiceSchema(AuditSchema, BaseSchema):  # pylint: disable=too-many-ancest
         if data.get('status_code') == InvoiceStatus.PAID.value:
             data['status_code'] = PaymentStatus.COMPLETED.value
 
-        # If it's a BUSINESS invoice, then push details.
-
-        if data.get('business_identifier', None):
-            corp_type: CorpType = CorpType.find_by_code(data.get('corp_type_code'))
-            if corp_type.product == Product.BUSINESS.value and corp_type.code != CorpTypeEnum.NRO.value:
-                details: list[dict] = data.get('details')
-                if not details:
-                    details = []
-                label = REGISTRATION_LABEL if corp_type.code in ('SP', 'GP') else INCORPORATION_LABEL
-                details.insert(0, dict(label=label, value=data.get('business_identifier')))
-                data['details'] = details
         return data

--- a/pay-api/src/pay_api/services/payment.py
+++ b/pay-api/src/pay_api/services/payment.py
@@ -351,22 +351,17 @@ class Payment:  # pylint: disable=too-many-instance-attributes, too-many-public-
         if data is None or 'items' not in data:
             data = {'items': []}
 
-        invoice_ids = []
         for invoice_dao in purchases:
             invoice_schema = InvoiceSchema(exclude=('receipts', 'payment_line_items', 'references'))
             invoice = invoice_schema.dump(invoice_dao)
             invoice['line_items'] = []
+            for payment_line_item in invoice_dao.payment_line_items:
+                line_item_schema = PaymentLineItemSchema(exclude=('id', 'line_item_status_code'))
+                line_item_dict = line_item_schema.dump(payment_line_item)
+                line_item_dict['filing_type_code'] = payment_line_item.fee_schedule.filing_type_code
+                invoice['line_items'].append(line_item_dict)
             data['items'].append(invoice)
-            invoice_ids.append(invoice_dao.id)
-        # Query the payment line item to retrieve more details
-        payment_line_items = PaymentLineItem.find_by_invoice_ids(invoice_ids)
-        for payment_line_item in payment_line_items:
-            for invoice in data['items']:
-                if invoice.get('id') == payment_line_item.invoice_id:
-                    line_item_schema = PaymentLineItemSchema(many=False, exclude=('id', 'line_item_status_code'))
-                    line_item_dict = line_item_schema.dump(payment_line_item)
-                    line_item_dict['filing_type_code'] = payment_line_item.fee_schedule.filing_type_code
-                    invoice.get('line_items').append(line_item_dict)
+
         return data
 
     @staticmethod

--- a/pay-api/src/pay_api/utils/constants.py
+++ b/pay-api/src/pay_api/utils/constants.py
@@ -48,8 +48,6 @@ ALL_ALLOWED_ROLES = (EDIT_ROLE, VIEW_ROLE)
 
 LEGISLATIVE_TIMEZONE = 'America/Vancouver'
 DT_SHORT_FORMAT = '%Y-%m-%d'
-INCORPORATION_LABEL = 'Incorporation Number:'
-REGISTRATION_LABEL = 'Registration Number:'
 
 REFUND_SUCCESS_MESSAGES = {
     'PAD.APPROVED': 'Your transaction has been cancelled. We will not request the initial payment from your bank.',

--- a/pay-api/src/pay_api/version.py
+++ b/pay-api/src/pay_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.18.0'  # pylint: disable=invalid-name
+__version__ = '1.18.1'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/12777

*Description of changes:*
- Remove LEAR code, which can possibly be called on every invoice queried (corp type code lookup for receipt)
- Include migration for above, also fix it in lear: https://github.com/bcgov/lear/pull/1881
- Optimize `search_purchase_history` to use only needed fields and joins
- Fix `create_payment_report_details` so it wont requery the database when the information is already available


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
