### PR TITLE
14618 - Fix from feedback, casting float to Decimal.

### DIFF
--- a/pay-api/src/pay_api/services/fas/routing_slip.py
+++ b/pay-api/src/pay_api/services/fas/routing_slip.py
@@ -431,18 +431,18 @@ class RoutingSlip:  # pylint: disable=too-many-instance-attributes, too-many-pub
         payments = PaymentModel.find_payments_for_routing_slip(rs_number)
         for payment_request in request_json.get('payments'):
             if (payment := next(x for x in payments if x.id == payment_request.get('id'))):
-                paid_amount = payment_request.get('paidAmount', 0)
+                paid_amount = Decimal(payment_request.get('paidAmount', 0))
                 correction_total += paid_amount - payment.paid_amount
                 if payment.payment_method_code == PaymentMethod.CASH.value:
                     comment += f'Cash Payment corrected amount' \
-                        f' ${payment.paid_amount} to ${paid_amount}\n'
+                        f' from ${payment.paid_amount} to ${paid_amount}\n'
                 else:
                     comment += f'Cheque Payment {payment.cheque_receipt_number}'
                     if cheque_receipt_number := payment_request.get('chequeReceiptNumber'):
                         payment.cheque_receipt_number = cheque_receipt_number
-                        comment += f' cheque receipt number corrected to {cheque_receipt_number}'
+                        comment += f', cheque receipt number corrected to {cheque_receipt_number}'
                     if paid_amount != payment.paid_amount:
-                        comment += f' corrected amount ${payment.paid_amount} to ${paid_amount}'
+                        comment += f', corrected amount from ${payment.paid_amount} to ${paid_amount}'
                     comment += '\n'
                 payment.paid_amount = paid_amount
                 payment.paid_usd_amount = payment_request.get('paidUsdAmount', 0)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/14618

*Description of changes:*
Fix from feedback, casting float to Decimal.

```
  File "/opt/app-root/src/pay_api/services/fas/routing_slip.py", line 417, in update
    correction_total, comment = cls._calculate_correction_and_comment(rs_number, request_json)
  File "/opt/app-root/src/pay_api/services/fas/routing_slip.py", line 435, in _calculate_correction_and_comment
    correction_total += paid_amount - payment.paid_amount
TypeError: unsupported operand type(s) for -: 'float' and 'decimal.Decimal'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
