### PR TITLE
Use decimal instead of float. 

### DIFF
--- a/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
+++ b/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
@@ -26,9 +26,9 @@ the model to a standalone SQLAlchemy usage with an async engine would need
 to be pursued.
 """
 import csv
-from decimal import Decimal
 import os
 from datetime import datetime
+from decimal import Decimal
 from typing import Dict, List, Tuple
 
 from entity_queue_common.service_utils import logger

--- a/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
+++ b/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
@@ -26,6 +26,7 @@ the model to a standalone SQLAlchemy usage with an async engine would need
 to be pursued.
 """
 import csv
+from decimal import Decimal
 import os
 from datetime import datetime
 from typing import Dict, List, Tuple
@@ -418,7 +419,7 @@ def _process_partial_paid_invoices(inv_ref: InvoiceReferenceModel, row):
     _validate_account(inv, row)
     logger.debug('Partial Invoice. Invoice Reference ID : %s, invoice ID : %s', inv_ref.id, inv_ref.invoice_id)
     inv.invoice_status_code = InvoiceStatus.PARTIAL.value
-    inv.paid = inv.total - float(_get_row_value(row, Column.TARGET_TXN_OUTSTANDING))
+    inv.paid = inv.total - Decimal(_get_row_value(row, Column.TARGET_TXN_OUTSTANDING))
     # Create Receipt records
     receipt: ReceiptModel = ReceiptModel()
     receipt.receipt_date = receipt_date


### PR DESCRIPTION
Fixes error:

unsupported operand type(s) for -: 'decimal.Decimal' and 'float' https://registries.sentry.io/issues/3947202203/?end=2023-02-21T10%3A23%3A06&project=1762954&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&referrer=issue-stream&sort=inbox&start=2022-11-23T10%3A23%3A06&utc=true



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
