### PR TITLE
Fix for bcol logging.

### DIFF
--- a/pay-api/src/pay_api/services/bcol_service.py
+++ b/pay-api/src/pay_api/services/bcol_service.py
@@ -98,12 +98,12 @@ class BcolService(PaymentSystemService, OAuthService):
             current_app.logger.debug(f'BCOL Response : {response_json}')
             pay_response.raise_for_status()
         except HTTPError as bol_err:
-            current_app.logger.error(bol_err)
-            error_type: str = response_json.get('type')
-            if error_type.isdigit():
-                error = get_bcol_error(int(error_type))
+            error_type: str = response_json.get('type', '-1')
+            error = get_bcol_error(int(error_type))
+            if error in [Error.BCOL_ERROR, Error.BCOL_UNAVAILABLE]:
+                current_app.logger.error(bol_err)
             else:
-                error = Error.BCOL_ERROR
+                current_app.logger.warning(bol_err)
             raise BusinessException(error) from bol_err
 
         invoice_reference: InvoiceReference = InvoiceReference.create(invoice.id, response_json.get('key'),


### PR DESCRIPTION
*Description of changes:*
Fixes this, as it could be valid. 

```
2023-02-21 15:13:06,492 - pay_api - ERROR in bcol_service:bcol_service.py:101 - create_invoice: 400 Client Error: BAD REQUEST for url: https://bcol-api.apps.silver.devops.gov.bc.ca/api/v1/payments
2023-02-21 15:13:06,494 - pay_api - ERROR in payment_service:payment_service.py:126 - create_invoice: Rolling back as error occured!
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
