### PR TITLE
To fix all notebook reports Sent but not delivered Issue#2247

### DIFF
--- a/jobs/notebook-report/notebookreport.py
+++ b/jobs/notebook-report/notebookreport.py
@@ -74,7 +74,7 @@ def send_email(file_processing, emailtype, errormessage):
             recipients = Config.MONTHLY_RECONCILIATION_RECIPIENTS
 
     # Add body to email
-    message.attach(MIMEText('Please see attached.', 'plain'))
+    message.attach(MIMEText('Please see the attachment(s).', 'plain'))
 
     for file in filenames:
         part = MIMEBase('application', 'octet-stream')


### PR DESCRIPTION
*Issue #:* 2247
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
All notebook reports (including Namex, LEAR, PAY notebook reports) were sent but didn't deliver to the receivers. The reason for this is that the contents in the email body were filter by the email server. Need to update codes to fix this issue.

https://app.zenhub.com/workspaces/entity-5bf2f2164b5806bc2bf60531/issues/gh/bcgov-registries/ops-support/2247

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
