### PR TITLE
15467 - Allow statements job to have a date override

### DIFF
--- a/jobs/payment-jobs/invoke_jobs.py
+++ b/jobs/payment-jobs/invoke_jobs.py
@@ -72,7 +72,7 @@ def register_shellcontext(app):
     app.shell_context_processor(shell_context)
 
 
-def run(job_name):
+def run(job_name, argument):
     from tasks.cfs_create_account_task import CreateAccountTask
     from tasks.cfs_create_invoice_task import CreateInvoiceTask
     from tasks.distribution_task import DistributionTask
@@ -95,7 +95,7 @@ def run(job_name):
         DistributionTask.update_failed_distributions()
         application.logger.info(f'<<<< Completed Updating GL Codes >>>>')
     elif job_name == 'GENERATE_STATEMENTS':
-        StatementTask.generate_statements()
+        StatementTask.generate_statements(argument)
         application.logger.info(f'<<<< Completed Generating Statements >>>>')
     elif job_name == 'SEND_NOTIFICATIONS':
         StatementNotificationTask.send_notifications()
@@ -143,4 +143,4 @@ def run(job_name):
 
 if __name__ == "__main__":
     print('----------------------------Scheduler Ran With Argument--', sys.argv[1])
-    run(sys.argv[1])
+    run(sys.argv[1], sys.argv[2])

--- a/jobs/payment-jobs/invoke_jobs.py
+++ b/jobs/payment-jobs/invoke_jobs.py
@@ -72,7 +72,7 @@ def register_shellcontext(app):
     app.shell_context_processor(shell_context)
 
 
-def run(job_name, argument):
+def run(job_name, argument=None):
     from tasks.cfs_create_account_task import CreateAccountTask
     from tasks.cfs_create_invoice_task import CreateInvoiceTask
     from tasks.distribution_task import DistributionTask
@@ -143,4 +143,7 @@ def run(job_name, argument):
 
 if __name__ == "__main__":
     print('----------------------------Scheduler Ran With Argument--', sys.argv[1])
-    run(sys.argv[1], sys.argv[2])
+    if (len(sys.argv) > 2):
+        run(sys.argv[1], sys.argv[2])
+    else:
+        run(sys.argv[1])

--- a/jobs/payment-jobs/tasks/statement_task.py
+++ b/jobs/payment-jobs/tasks/statement_task.py
@@ -40,8 +40,8 @@ class StatementTask:  # pylint:disable=too-few-public-methods
         Steps:
         1. Get all payment accounts and it's active statement settings.
         """
-        # We add a day here for override, because the target always looks at yesterday,
-        # the date_override, is supposed to generate statements for the specified date.
+        # We add a day here for override because the target always looks at yesterday.
+        # The date_override is supposed to generate statements for the specified date.
         current_time = datetime.now() if date_override is None \
             else datetime.strptime(date_override, '%Y-%m-%d') + timedelta(days=1)
         current_time = get_local_time(current_time)

--- a/jobs/payment-jobs/tasks/statement_task.py
+++ b/jobs/payment-jobs/tasks/statement_task.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Service to manage PAYBC services."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from dateutil.parser import parse
 from flask import current_app
@@ -30,15 +30,23 @@ from pay_api.utils.util import (
 
 class StatementTask:  # pylint:disable=too-few-public-methods
     """Task to generate statements."""
+    skip_notify: bool = False
 
     @classmethod
-    def generate_statements(cls):
+    def generate_statements(cls, date_override=None):
         """Generate statements.
-
+        
         Steps:
         1. Get all payment accounts and it's active statement settings.
         """
-        current_time = get_local_time(datetime.now())
+        # We add a day here for override, because the target always looks at yesterday, 
+        # the date_override, is supposed to generate statements for the specified date.
+        current_time = datetime.now() if date_override is None \
+              else datetime.strptime(date_override, '%Y-%m-%d') + timedelta(days=1)
+        current_time = get_local_time(current_time)
+        cls.skip_notify = date_override is not None
+        if date_override:
+            current_app.logger.debug(f'Generating statements for: {date_override} using date override.')
         # If today is sunday - generate all weekly statements for pervious week
         # If today is month beginning - generate all monthly statements for previous month
         # For every day generate all daily statements for previous day
@@ -122,7 +130,7 @@ class StatementTask:  # pylint:disable=too-few-public-methods
                 from_date=statement_from,
                 to_date=statement_to,
                 notification_status_code=NotificationStatus.PENDING.value
-                if pay_account.statement_notification_enabled is True
+                if pay_account.statement_notification_enabled is True and cls.skip_notify is False
                 else NotificationStatus.SKIP.value
 
             )
@@ -143,5 +151,3 @@ class StatementTask:  # pylint:disable=too-few-public-methods
                     invoice_id=invoice.id
                 )
                 db.session.add(statement_invoice)
-
-            # TODO Send an email notification

--- a/jobs/payment-jobs/tasks/statement_task.py
+++ b/jobs/payment-jobs/tasks/statement_task.py
@@ -39,7 +39,7 @@ class StatementTask:  # pylint:disable=too-few-public-methods
         Steps:
         1. Get all payment accounts and it's active statement settings.
         """
-        # We add a day here for override, because the target always looks at yesterday, 
+        # We add a day here for override, because the target always looks at yesterday,
         # the date_override, is supposed to generate statements for the specified date.
         current_time = datetime.now() if date_override is None \
               else datetime.strptime(date_override, '%Y-%m-%d') + timedelta(days=1)

--- a/jobs/payment-jobs/tasks/statement_task.py
+++ b/jobs/payment-jobs/tasks/statement_task.py
@@ -42,7 +42,7 @@ class StatementTask:  # pylint:disable=too-few-public-methods
         # We add a day here for override, because the target always looks at yesterday,
         # the date_override, is supposed to generate statements for the specified date.
         current_time = datetime.now() if date_override is None \
-              else datetime.strptime(date_override, '%Y-%m-%d') + timedelta(days=1)
+            else datetime.strptime(date_override, '%Y-%m-%d') + timedelta(days=1)
         current_time = get_local_time(current_time)
         cls.skip_notify = date_override is not None
         if date_override:

--- a/jobs/payment-jobs/tasks/statement_task.py
+++ b/jobs/payment-jobs/tasks/statement_task.py
@@ -30,12 +30,13 @@ from pay_api.utils.util import (
 
 class StatementTask:  # pylint:disable=too-few-public-methods
     """Task to generate statements."""
+
     skip_notify: bool = False
 
     @classmethod
     def generate_statements(cls, date_override=None):
         """Generate statements.
-        
+
         Steps:
         1. Get all payment accounts and it's active statement settings.
         """

--- a/jobs/payment-jobs/tests/jobs/test_generate_statements.py
+++ b/jobs/payment-jobs/tests/jobs/test_generate_statements.py
@@ -60,7 +60,7 @@ def test_statements(session):
     assert invoices[0].id == invoice.id
 
     # Test date override.
-    StatementTask.generate_statements(datetime.now().strftime("%Y-%m-%d"))
+    StatementTask.generate_statements(datetime.now().strftime('%Y-%m-%d'))
 
     statements = Statement.find_all_statements_for_account(auth_account_id=bcol_account.auth_account_id, page=1,
                                                            limit=100)

--- a/jobs/payment-jobs/tests/jobs/test_generate_statements.py
+++ b/jobs/payment-jobs/tests/jobs/test_generate_statements.py
@@ -59,6 +59,16 @@ def test_statements(session):
     assert invoices is not None
     assert invoices[0].id == invoice.id
 
+    # Test date override.
+    StatementTask.generate_statements(datetime.now().strftime("%Y-%m-%d"))
+
+    statements = Statement.find_all_statements_for_account(auth_account_id=bcol_account.auth_account_id, page=1,
+                                                           limit=100)
+    assert statements is not None
+    invoices = StatementInvoices.find_all_invoices_for_statement(statements[0][0].id)
+    assert invoices is not None
+    assert invoices[0].id == invoice.id
+
 
 def test_statements_for_empty_results(session):
     """Test dailiy statement generation works.

--- a/pay-api/src/pay_api/models/payment_account.py
+++ b/pay-api/src/pay_api/models/payment_account.py
@@ -82,7 +82,7 @@ class PaymentAccountSearchModel:  # pylint: disable=too-few-public-methods
 
     name: str
     billable: bool
-    auth_account_id: str
+    account_id: str
 
     @classmethod
     def from_row(cls, row: PaymentAccount):
@@ -90,4 +90,4 @@ class PaymentAccountSearchModel:  # pylint: disable=too-few-public-methods
 
         https://www.attrs.org/en/stable/init.html
         """
-        return cls(name=row.name, billable=row.billable, auth_account_id=row.auth_account_id)
+        return cls(name=row.name, billable=row.billable, account_id=row.auth_account_id)

--- a/pay-api/src/pay_api/models/payment_account.py
+++ b/pay-api/src/pay_api/models/payment_account.py
@@ -80,7 +80,7 @@ class PaymentAccountSchema(BaseSchema):  # pylint: disable=too-many-ancestors
 class PaymentAccountSearchModel:  # pylint: disable=too-few-public-methods
     """Payment Account Search model."""
 
-    name: str
+    account_name: str
     billable: bool
     account_id: str
 
@@ -90,4 +90,4 @@ class PaymentAccountSearchModel:  # pylint: disable=too-few-public-methods
 
         https://www.attrs.org/en/stable/init.html
         """
-        return cls(name=row.name, billable=row.billable, account_id=row.auth_account_id)
+        return cls(account_name=row.name, billable=row.billable, account_id=row.auth_account_id)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/15467

*Description of changes:*
Allow statements job to have a date override - that way we can generate statements where there are gaps.
I've also moved the statement job to 8 UTC (from 7 UTC), this way it doesn't cause gaps when daylight savings switches.

Usage:
`python invoke_jobs.py GENERATE_STATEMENTS 2022-01-01`



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
