### PR TITLE
Small fix for payment reconciliation for online banking.

### DIFF
--- a/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
+++ b/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
@@ -175,6 +175,9 @@ def _get_failed_payment_by_inv_number(inv_number: str) -> PaymentModel:
 
 def _get_payment_by_inv_number_and_status(inv_number: str, status: str) -> PaymentModel:
     """Get payment by invoice number and status."""
+    # It's possible to look up null inv_number and return more than one.
+    if inv_number is None:
+        return None
     payment: PaymentModel = db.session.query(PaymentModel) \
         .filter(PaymentModel.invoice_number == inv_number,
                 PaymentModel.payment_status_code == status) \


### PR DESCRIPTION
```
2023-03-15 21:40:45,595 - asyncio - ERROR in worker:worker.py:76 - cb_subscription_handler: Queue Error: {"specversion": "1.x-wip", "type": "bc.registry.payment.casSettlementUploaded", "source": "https://api.business.bcregistry.gov.bc.ca/v1/business/BC1234567/filing/12345678", "id": "C234-1234-1234", "time": "2020-08-28T17:37:34.651294+00:00", "datacontenttype": "application/json", "data": {"fileName": "BCR_PAYMENT_APPL_20230228.csv", "source": "MINIO", "location": "payment-sftp"}}
Traceback (most recent call last):
  File "/opt/app-root/src/reconciliations/worker.py", line 73, in cb_subscription_handler
    await process_event(event_message, FLASK_APP)
  File "/opt/app-root/src/reconciliations/worker.py", line 58, in process_event
    await reconcile_payments(event_message)
  File "/opt/app-root/src/reconciliations/payment_reconciliations.py", line 250, in reconcile_payments
    await _create_payment_records(content)
  File "/opt/app-root/src/reconciliations/payment_reconciliations.py", line 115, in _create_payment_records
    _save_payment(payment_date, inv_number, invoice_amount, paid_amount, row, PaymentStatus.COMPLETED.value,
  File "/opt/app-root/src/reconciliations/payment_reconciliations.py", line 148, in _save_payment
    payment = _get_payment_by_inv_number_and_status(inv_number, PaymentStatus.COMPLETED.value)
  File "/opt/app-root/src/reconciliations/payment_reconciliations.py", line 177, in _get_payment_by_inv_number_and_status
    payment: PaymentModel = db.session.query(PaymentModel) \
  File "/usr/local/lib/python3.8/site-packages/sqlalchemy/orm/query.py", line 3467, in one_or_none
    raise orm_exc.MultipleResultsFound(
sqlalchemy.orm.exc.MultipleResultsFound: Multiple rows were found for one_or_none()
2023-03-15 21:40:45,600 - asyncio - ERROR in worker:worker.py:77 - cb_subscription_handler: Multiple rows were found for one_or_none()
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
