### PR TITLE
Lock holiday to 0.23 for now.

### DIFF
--- a/pay-api/requirements/prod.txt
+++ b/pay-api/requirements/prod.txt
@@ -29,4 +29,4 @@ itsdangerous==2.0.1
 Jinja2==3.0.3
 protobuf~=3.19.5
 launchdarkly-server-sdk
-holidays
+holidays==0.23


### PR DESCRIPTION

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
