### PR TITLE
adding the vault for gcp-queue

### DIFF
--- a/pay-api/devops/vaults.json
+++ b/pay-api/devops/vaults.json
@@ -23,6 +23,12 @@
         ]
     },
     {
+        "vault": "gcp-queue",
+        "application": [
+            "payment"
+        ]
+    },
+    {
         "vault": "payment-external-services",
         "application": [
             "paybc",


### PR DESCRIPTION
This will enable the posting of messages to the queue in dev only

Adding the vault for gcp-queue payment section for dev-test-sandbox-prod

Only dev has values, but the keys are in the 1Password vault.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
