### PR TITLE
16789 - Change _get_payment_account, so it doesn't fail when there are multip…

### DIFF
--- a/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
+++ b/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
@@ -554,7 +554,7 @@ def _get_payment_account(row) -> PaymentAccountModel:
         CfsAccountModel.status.in_(
             [CfsAccountStatus.ACTIVE.value, CfsAccountStatus.FREEZE.value, CfsAccountStatus.INACTIVE.value]
         )).all()
-    if not all([payment_account.id == payment_accounts[0].id for payment_account in payment_accounts]):
+    if not all(payment_account.id == payment_accounts[0].id for payment_account in payment_accounts):
         raise Exception('Multiple unique payment accounts for cfs_account.')  # pylint: disable=broad-exception-raised
     return payment_accounts[0] if payment_accounts else None
 

--- a/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
+++ b/queue_services/payment-reconciliations/src/reconciliations/payment_reconciliations.py
@@ -547,15 +547,16 @@ def _sync_credit_records():
 
 def _get_payment_account(row) -> PaymentAccountModel:
     account_number: str = _get_row_value(row, Column.CUSTOMER_ACC)
-    payment_account: PaymentAccountModel = db.session.query(PaymentAccountModel) \
+    payment_accounts: PaymentAccountModel = db.session.query(PaymentAccountModel) \
         .join(CfsAccountModel, CfsAccountModel.account_id == PaymentAccountModel.id) \
         .filter(CfsAccountModel.cfs_account == account_number) \
         .filter(
         CfsAccountModel.status.in_(
             [CfsAccountStatus.ACTIVE.value, CfsAccountStatus.FREEZE.value, CfsAccountStatus.INACTIVE.value]
-        )).one_or_none()
-
-    return payment_account
+        )).all()
+    if not all([payment_account.id == payment_accounts[0].id for payment_account in payment_accounts]):
+        raise Exception('Multiple unique payment accounts for cfs_account.')  # pylint: disable=broad-exception-raised
+    return payment_accounts[0] if payment_accounts else None
 
 
 def _validate_account(inv: InvoiceModel, row: Dict[str, str]):


### PR DESCRIPTION
…le rows with the same PaymentAccount.id.

*Issue #:*
https://github.com/bcgov/entity/issues/16789

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
