### PR TITLE
17477 - Correct overwriting at footer of Online Banking Payment Invoice

### DIFF
--- a/report-api/report-templates/invoice.html
+++ b/report-api/report-templates/invoice.html
@@ -287,6 +287,7 @@
         bottom: 54px;
         left: -24px;
         width: 100%;
+        margin-bottom: -100px;
       }
 
       .footer-bcrs-logo {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/17477

*Description of changes:*
invoice before:
<img width="523" alt="image" src="https://github.com/bcgov/sbc-pay/assets/16507223/4c988be6-c2df-4eeb-b49b-5114dcba3ce3">
invoice update as:
<img width="519" alt="image" src="https://github.com/bcgov/sbc-pay/assets/16507223/5eea44dd-f697-4ddd-a964-c0d7432720eb">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
