### PR TITLE
Add in fields back to the response for CSO.

### DIFF
--- a/jobs/payment-jobs/tests/docker/docker-compose.yml
+++ b/jobs/payment-jobs/tests/docker/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     image: stoplight/prism:3.3.0
     command: >
       mock -p 4010 --host 0.0.0.0
-      https://raw.githubusercontent.com/bcgov/sbc-pay/main/docs/docs/api_contract/pay-api-1.0.4.yaml
+      https://raw.githubusercontent.com/bcgov/sbc-pay/main/docs/docs/api_contract/pay-api-1.0.5.yaml
   reports:
     image: stoplight/prism:3.3.0
     command: >

--- a/pay-api/src/pay_api/models/invoice.py
+++ b/pay-api/src/pay_api/models/invoice.py
@@ -251,6 +251,9 @@ class InvoiceSearchModel:  # pylint: disable=too-few-public-methods, too-many-in
     line_items: Optional[List[PaymentLineItemSearchModel]]
     product: str
     invoice_number: str
+    payment_date: datetime
+    refund_date: datetime
+    disbursement_date: datetime
 
     @classmethod
     def from_row(cls, row):
@@ -276,4 +279,7 @@ class InvoiceSearchModel:  # pylint: disable=too-few-public-methods, too-many-in
                    payment_account=PaymentAccountSearchModel.from_row(row.payment_account),
                    line_items=line_items,
                    product=row.corp_type.product,
+                   payment_date=row.payment_date,
+                   refund_date=row.refund_date,
+                   disbursement_date=row.disbursement_date,
                    invoice_number=invoice_number)

--- a/pay-api/src/pay_api/utils/converter.py
+++ b/pay-api/src/pay_api/utils/converter.py
@@ -21,7 +21,7 @@ class Converter(cattrs.Converter):
 
     @staticmethod
     def _unstructure_datetime(obj: datetime) -> str:
-        return obj.isoformat()
+        return obj.isoformat() if obj else None
 
     @staticmethod
     def remove_nones(data: Dict[Any, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
*Description of changes:*

"Would it be possible to set the appropriate date fields for the following transactions on your side so I can test our reconciliation is getting them correctly?

713332
713330
712969 refund

Paid Date, Refund Date, or Disbursement Date
"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
