### PR TITLE
17224/17829 - EFT over due status handling updates

### DIFF
--- a/pay-api/src/pay_api/models/invoice.py
+++ b/pay-api/src/pay_api/models/invoice.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 from typing import List, Optional
+from dateutil.relativedelta import relativedelta
 from attrs import define
 
 from marshmallow import fields, post_dump
@@ -34,6 +35,7 @@ from .invoice_reference import InvoiceReferenceSchema
 from .payment_account import PaymentAccountSchema, PaymentAccountSearchModel
 from .payment_line_item import PaymentLineItem, PaymentLineItemSchema
 from .receipt import ReceiptSchema
+from ..utils.util import current_local_time
 
 
 class Invoice(Audit):  # pylint: disable=too-many-instance-attributes
@@ -98,7 +100,9 @@ class Invoice(Audit):  # pylint: disable=too-many-instance-attributes
     total = db.Column(db.Numeric(19, 2), nullable=False)
     paid = db.Column(db.Numeric(19, 2), nullable=True)
     payment_date = db.Column(db.DateTime, nullable=True)
-    overdue_date = db.Column(db.DateTime, nullable=True)
+    # default overdue_date to the first of next month
+    overdue_date = db.Column(db.DateTime, nullable=True,
+                             default=lambda: current_local_time() + relativedelta(months=1, day=1))
     refund_date = db.Column(db.DateTime, nullable=True)
     refund = db.Column(db.Numeric(19, 2), nullable=True)
     routing_slip = db.Column(db.String(50), nullable=True, index=True)

--- a/pay-api/tests/unit/models/test_invoice.py
+++ b/pay-api/tests/unit/models/test_invoice.py
@@ -16,8 +16,11 @@
 
 Test-Suite to ensure that the CorpType Class is working as expected.
 """
+from dateutil.relativedelta import relativedelta
+
 from pay_api.models import Invoice, InvoiceSchema
 from pay_api.utils.enums import InvoiceStatus
+from pay_api.utils.util import current_local_time
 from tests.utilities.base_test import factory_invoice, factory_payment, factory_payment_account
 
 
@@ -33,6 +36,10 @@ def test_invoice(session):
     invoice = factory_invoice(payment_account=payment_account)
     invoice.save()
     assert invoice.id is not None
+
+    # assert overdue default is set
+    assert invoice.overdue_date is not None
+    assert invoice.overdue_date.date() == (current_local_time() + relativedelta(months=1, day=1)).date()
 
 
 def test_invoice_find_by_id(session):


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/17224
https://github.com/bcgov/entity/issues/17829
*Description of changes:*
- set default overdue date when creating an invoice
- update account summary logic invoice statuses to filter on and allow filtering on a particular statement


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
