### PR TITLE
Remove default=False, put in server_default='f'

### DIFF
--- a/pay-api/migrations/versions/2023_10_26_2ef58b39cafc_add_eft_enable_to_payment_accounts.py
+++ b/pay-api/migrations/versions/2023_10_26_2ef58b39cafc_add_eft_enable_to_payment_accounts.py
@@ -18,8 +18,8 @@ depends_on = None
 
 def upgrade():
     op.execute("set statement_timeout=20000;")
-    op.add_column('payment_accounts', sa.Column('eft_enable', sa.Boolean(), nullable=False, default=False))
-    op.add_column('payment_accounts_version', sa.Column('eft_enable', sa.Boolean(), nullable=False, default=False))
+    op.add_column('payment_accounts', sa.Column('eft_enable', sa.Boolean(), nullable=False, server_default='f'))
+    op.add_column('payment_accounts_version', sa.Column('eft_enable', sa.Boolean(), nullable=False, server_default='f'))
 
 
 def downgrade():


### PR DESCRIPTION
Issue with CD

75File "/usr/local/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 608, in do_execute
76cursor.execute(statement, parameters)
77sqlalchemy.exc.IntegrityError: (psycopg2.errors.NotNullViolation) column "eft_enable" of relation "payment_accounts" contains null values
78
79[SQL: ALTER TABLE payment_accounts ADD COLUMN eft_enable BOOLEAN NOT NULL]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
