### PR TITLE
18510 - Add extra step to set transactions to REFUNDED if billable = 'f'

### DIFF
--- a/pay-api/src/pay_api/services/base_payment_system.py
+++ b/pay-api/src/pay_api/services/base_payment_system.py
@@ -102,7 +102,8 @@ class PaymentSystemService(ABC):  # pylint: disable=too-many-instance-attributes
         """Return the payment system portal URL for payment."""
         return None
 
-    def process_cfs_refund(self, invoice: InvoiceModel):  # pylint:disable=unused-argument
+    def process_cfs_refund(self, invoice: InvoiceModel,  # pylint:disable=unused-argument
+                           payment_account: PaymentAccount):  # pylint:disable=unused-argument
         """Process Refund if any."""
         return None
 

--- a/pay-api/src/pay_api/services/bcol_service.py
+++ b/pay-api/src/pay_api/services/bcol_service.py
@@ -147,7 +147,8 @@ class BcolService(PaymentSystemService, OAuthService):
         """Return CC as the method code."""
         return PaymentMethod.DRAWDOWN.value
 
-    def process_cfs_refund(self, invoice: InvoiceModel):
+    def process_cfs_refund(self, invoice: InvoiceModel,
+                           payment_account: PaymentAccount):  # pylint:disable=unused-argument
         """Process refund in CFS."""
         self._publish_refund_to_mailer(invoice)
         payment: PaymentModel = PaymentModel.find_payment_for_invoice(invoice.id)

--- a/pay-api/src/pay_api/services/direct_pay_service.py
+++ b/pay-api/src/pay_api/services/direct_pay_service.py
@@ -140,7 +140,8 @@ class DirectPayService(PaymentSystemService, OAuthService):
                 return pay_system_reason_code
         return None
 
-    def process_cfs_refund(self, invoice: InvoiceModel):
+    def process_cfs_refund(self, invoice: InvoiceModel,
+                           payment_account: PaymentAccount):   # pylint:disable=unused-argument
         """Process refund in CFS."""
         current_app.logger.debug('<process_cfs_refund creating automated refund for invoice: '
                                  f'{invoice.id}, {invoice.invoice_status_code}')

--- a/pay-api/src/pay_api/services/internal_pay_service.py
+++ b/pay-api/src/pay_api/services/internal_pay_service.py
@@ -90,7 +90,8 @@ class InternalPayService(PaymentSystemService, OAuthService):
         """Return the default status for invoice when created."""
         return InvoiceStatus.APPROVED.value
 
-    def process_cfs_refund(self, invoice: InvoiceModel):
+    def process_cfs_refund(self, invoice: InvoiceModel,
+                           payment_account: PaymentAccount):  # pylint:disable=unused-argument
         """Process refund in CFS."""
         if invoice.total == 0:
             raise BusinessException(Error.NO_FEE_REFUND)

--- a/pay-api/src/pay_api/services/online_banking_service.py
+++ b/pay-api/src/pay_api/services/online_banking_service.py
@@ -66,6 +66,7 @@ class OnlineBankingService(PaymentSystemService, CFSService):
         current_app.logger.debug('<cancel_invoice %s, %s', payment_account, inv_number)
         self.reverse_invoice(inv_number)
 
-    def process_cfs_refund(self, invoice: InvoiceModel):
+    def process_cfs_refund(self, invoice: InvoiceModel,
+                           payment_account: PaymentAccount):  # pylint:disable=unused-argument
         """Process refund in CFS."""
         return super()._refund_and_create_credit_memo(invoice)

--- a/pay-api/src/pay_api/services/pad_service.py
+++ b/pay-api/src/pay_api/services/pad_service.py
@@ -116,7 +116,8 @@ class PadService(PaymentSystemService, CFSService):
         # Publish message to the queue with payment token, so that they can release records on their side.
         self._release_payment(invoice=invoice)
 
-    def process_cfs_refund(self, invoice: InvoiceModel):
+    def process_cfs_refund(self, invoice: InvoiceModel,
+                           payment_account: PaymentAccount):  # pylint:disable=unused-argument
         """Process refund in CFS."""
         # Move invoice to CREDITED or CANCELLED. There are no refunds for PAD, just cancellation or credit.
         # Credit memos don't return to the bank account.

--- a/pay-api/src/pay_api/services/paybc_service.py
+++ b/pay-api/src/pay_api/services/paybc_service.py
@@ -145,7 +145,8 @@ class PaybcService(PaymentSystemService, CFSService):
         receipt_url = receipt_url + f'{receipt_number}/'
         return self.get(receipt_url, access_token, AuthHeaderType.BEARER, ContentType.JSON, True).json()
 
-    def process_cfs_refund(self, invoice: InvoiceModel):
+    def process_cfs_refund(self, invoice: InvoiceModel,
+                           payment_account: PaymentAccount):  # pylint:disable=unused-argument
         """Process refund in CFS."""
         return super()._refund_and_create_credit_memo(invoice)
 

--- a/pay-api/src/pay_api/services/refund.py
+++ b/pay-api/src/pay_api/services/refund.py
@@ -26,6 +26,7 @@ from pay_api.models import Invoice as InvoiceModel
 from pay_api.models import Refund as RefundModel
 from pay_api.models import RoutingSlip as RoutingSlipModel
 from pay_api.services.base_payment_system import PaymentSystemService
+from pay_api.services.payment_account import PaymentAccount
 from pay_api.utils.constants import REFUND_SUCCESS_MESSAGES
 from pay_api.utils.enums import InvoiceStatus, Role, RoutingSlipStatus
 from pay_api.utils.errors import Error
@@ -266,7 +267,8 @@ class RefundService:  # pylint: disable=too-many-instance-attributes
         pay_system_service: PaymentSystemService = PaymentSystemFactory.create_from_payment_method(
             payment_method=invoice.payment_method_code
         )
-        invoice_status = pay_system_service.process_cfs_refund(invoice)
+        payment_account = PaymentAccount.find_by_id(invoice.payment_account_id)
+        invoice_status = pay_system_service.process_cfs_refund(invoice, payment_account=payment_account)
         refund.flush()
         message = REFUND_SUCCESS_MESSAGES.get(f'{invoice.payment_method_code}.{invoice.invoice_status_code}')
         # set invoice status

--- a/pay-api/tests/unit/services/test_direct_pay_service.py
+++ b/pay-api/tests/unit/services/test_direct_pay_service.py
@@ -192,7 +192,7 @@ def test_process_cfs_refund_success(monkeypatch):
 
     direct_pay_service = DirectPayService()
 
-    direct_pay_service.process_cfs_refund(invoice)
+    direct_pay_service.process_cfs_refund(invoice, payment_account)
     assert True
 
 
@@ -208,7 +208,7 @@ def test_process_cfs_refund_bad_request():
     invoice.save()
     direct_pay_service = DirectPayService()
     with pytest.raises(BusinessException) as excinfo:
-        direct_pay_service.process_cfs_refund(invoice)
+        direct_pay_service.process_cfs_refund(invoice, payment_account)
         assert excinfo.value.code == Error.INVALID_REQUEST.name
 
 
@@ -241,7 +241,7 @@ def test_process_cfs_refund_duplicate_refund(monkeypatch):
             ]
         }
         with pytest.raises(HTTPError) as excinfo:
-            direct_pay_service.process_cfs_refund(invoice)
+            direct_pay_service.process_cfs_refund(invoice, payment_account)
             assert invoice.invoice_status_code == InvoiceStatus.PAID.value
 
     with patch('pay_api.services.oauth_service.requests.post') as mock_post:
@@ -257,5 +257,5 @@ def test_process_cfs_refund_duplicate_refund(monkeypatch):
             'txnNumber': 'REGT00005433'
         }
         with pytest.raises(BusinessException) as excinfo:
-            direct_pay_service.process_cfs_refund(invoice)
+            direct_pay_service.process_cfs_refund(invoice, payment_account)
             assert excinfo.value.code == Error.DIRECT_PAY_INVALID_RESPONSE.name

--- a/pay-api/tests/unit/services/test_payment_service.py
+++ b/pay-api/tests/unit/services/test_payment_service.py
@@ -24,6 +24,7 @@ from pay_api.models import FeeSchedule, Invoice, Payment, PaymentAccount
 from pay_api.models import RoutingSlip as RoutingSlipModel
 from pay_api.services import CFSService
 from pay_api.services.internal_pay_service import InternalPayService
+from pay_api.services.payment_account import PaymentAccount as PaymentAccountService
 from pay_api.services.payment_service import PaymentService
 from pay_api.utils.enums import InvoiceStatus, PaymentMethod, PaymentStatus, RoutingSlipStatus
 from requests.exceptions import ConnectionError, ConnectTimeout, HTTPError
@@ -388,6 +389,8 @@ def test_internal_rs_back_active(session, public_user_mock):
     assert rs.status == RoutingSlipStatus.COMPLETE.name
 
     invoice = Invoice.find_by_id(invoice['id'])
-    InternalPayService().process_cfs_refund(invoice)
+    payment_account = PaymentAccountService()
+    payment_account._dao = account_model  # pylint: disable=protected-access
+    InternalPayService().process_cfs_refund(invoice, payment_account)
 
     assert rs.status == RoutingSlipStatus.ACTIVE.name


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/18510

*Description of changes:*
Should fix: https://github.com/bcgov/entity/issues/17772

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
