### PR TITLE
18762 - EFT automatically set statement frequency to monthly

### DIFF
--- a/pay-api/src/pay_api/services/payment_account.py
+++ b/pay-api/src/pay_api/services/payment_account.py
@@ -356,8 +356,8 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
     @classmethod
     def _check_and_update_statement_settings(cls, payment_account: PaymentAccountModel):
         """Check and update statement settings based on payment method."""
-        # On create of a payment account keep in mind _persist_default_statement_frequency() is used, so we
-        # will only check if an update is needed only if statement settings already exists - i.e an update
+        # On create of a payment account _persist_default_statement_frequency() is used, so we
+        # will only check if an update is needed if statement settings already exists - i.e an update
         if payment_account and payment_account.payment_method == PaymentMethod.EFT.value:
             # EFT payment method should automatically set statement frequency to MONTHLY
             auth_account_id = str(payment_account.auth_account_id)

--- a/pay-api/src/pay_api/services/payment_account.py
+++ b/pay-api/src/pay_api/services/payment_account.py
@@ -35,6 +35,7 @@ from pay_api.models import db
 from pay_api.services.cfs_service import CFSService
 from pay_api.services.distribution_code import DistributionCode
 from pay_api.services.queue_publisher import publish_response
+from pay_api.services.statement_settings import StatementSettings
 from pay_api.utils.enums import (
     CfsAccountStatus, InvoiceStatus, MessageType, PaymentMethod, PaymentSystem, StatementFrequency)
 from pay_api.utils.errors import Error
@@ -353,6 +354,20 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
         return payment_account
 
     @classmethod
+    def _check_and_update_statement_settings(cls, payment_account: PaymentAccountModel):
+        """Check and update statement settings based on payment method."""
+        # On create of a payment account keep in mind _persist_default_statement_frequency() is used, so we
+        # will only check if an update is needed only if statement settings already exists - i.e an update
+        if payment_account and payment_account.payment_method == PaymentMethod.EFT.value:
+            # EFT payment method should automatically set statement frequency to MONTHLY
+            auth_account_id = str(payment_account.auth_account_id)
+            statements_settings: StatementSettingsModel = StatementSettingsModel\
+                .find_active_settings(auth_account_id, datetime.today())
+
+            if statements_settings is not None and statements_settings.frequency != StatementFrequency.MONTHLY.value:
+                StatementSettings.update_statement_settings(auth_account_id, StatementFrequency.MONTHLY.value)
+
+    @classmethod
     def _save_account(cls, account_request: Dict[str, any], payment_account: PaymentAccountModel,
                       is_sandbox: bool = False):
         """Update and save payment account and CFS account model."""
@@ -390,6 +405,7 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
         if payment_method:
             pay_system = PaymentSystemFactory.create_from_payment_method(payment_method=payment_method)
             cls._handle_payment_details(account_request, is_sandbox, pay_system, payment_account, payment_info)
+            cls._check_and_update_statement_settings(payment_account)
         payment_account.save()
 
     @classmethod
@@ -534,8 +550,15 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
 
     @staticmethod
     def _persist_default_statement_frequency(payment_account_id):
+        payment_account: PaymentAccountModel = PaymentAccountModel.find_by_id(payment_account_id)
+        frequency = StatementFrequency.default_frequency().value
+
+        # EFT Payment method default to MONTHLY frequency
+        if payment_account.payment_method == PaymentMethod.EFT.value:
+            frequency = StatementFrequency.MONTHLY.value
+
         statement_settings_model = StatementSettingsModel(
-            frequency=StatementFrequency.default_frequency().value,
+            frequency=frequency,
             payment_account_id=payment_account_id
         )
         statement_settings_model.save()

--- a/pay-api/src/pay_api/version.py
+++ b/pay-api/src/pay_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.20.3'  # pylint: disable=invalid-name
+__version__ = '1.20.4'  # pylint: disable=invalid-name

--- a/pay-api/tests/unit/services/test_payment_account.py
+++ b/pay-api/tests/unit/services/test_payment_account.py
@@ -27,8 +27,9 @@ from pay_api.models import EFTFile as EFTFileModel
 from pay_api.models import EFTCredit as EFTCreditModel
 from pay_api.models import EFTShortnames as EFTShortnameModel
 from pay_api.models import Invoice as InvoiceModel
+from pay_api.models import StatementSettings as StatementSettingsModel
 from pay_api.services.payment_account import PaymentAccount as PaymentAccountService
-from pay_api.utils.enums import CfsAccountStatus, InvoiceStatus, PaymentMethod
+from pay_api.utils.enums import CfsAccountStatus, InvoiceStatus, PaymentMethod, StatementFrequency
 from pay_api.utils.errors import Error
 from pay_api.utils.util import get_outstanding_txns_from_date
 from tests.utilities.base_test import (
@@ -336,3 +337,41 @@ def test_payment_request_eft_with_credit(session, client, jwt, app):
     assert invoice.invoice_status_code == InvoiceStatus.PAID.value
     assert eft_credit_1.remaining_amount == 0
     assert eft_credit_2.remaining_amount == 10
+
+
+def test_eft_payment_method_settings(session, client, jwt, app):
+    """Assert EFT payment method statement settings are applied."""
+    # Validate on account create with EFT payment method that statement settings are automatically set to MONTHLY
+    payment_account: PaymentAccountService = PaymentAccountService.create(
+        get_premium_account_payload(payment_method=PaymentMethod.EFT.value))
+
+    assert payment_account is not None
+    assert payment_account.payment_method == PaymentMethod.EFT.value
+
+    statement_settings: StatementSettingsModel = StatementSettingsModel\
+        .find_active_settings(str(payment_account.auth_account_id), datetime.today())
+
+    assert statement_settings is not None
+    assert statement_settings.frequency == StatementFrequency.MONTHLY.value
+
+    # Validate on account update to EFT payment method that statement settings are automatically set to MONTHLY
+    payment_account_2: PaymentAccountService = PaymentAccountService.create(
+        get_premium_account_payload(account_id=payment_account.id + 1,
+                                    payment_method=PaymentMethod.ONLINE_BANKING.value))
+
+    assert payment_account_2 is not None
+    assert payment_account_2.payment_method == PaymentMethod.ONLINE_BANKING.value
+
+    payment_account_2 = PaymentAccountService\
+        .update(payment_account_2.auth_account_id,
+                get_eft_enable_account_payload(payment_method=PaymentMethod.EFT.value,
+                                               account_id=payment_account_2.auth_account_id))
+
+    assert payment_account_2 is not None
+    assert payment_account_2.payment_method == PaymentMethod.EFT.value
+
+    statement_settings: StatementSettingsModel = StatementSettingsModel \
+        .find_latest_settings(str(payment_account_2.auth_account_id))
+
+    assert statement_settings is not None
+    assert statement_settings.frequency == StatementFrequency.MONTHLY.value


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/18762 

*Description of changes:*
- update default statement settings for EFT payment method for account creation
- update payment method change logic to check for EFT and ensure the correct statement frequency

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
