### PR TITLE
18955 - Change invoice status for get invoices for disbursement to include CR…

### DIFF
--- a/jobs/payment-jobs/tasks/ejv_partner_distribution_task.py
+++ b/jobs/payment-jobs/tasks/ejv_partner_distribution_task.py
@@ -71,8 +71,9 @@ class EjvPartnerDistributionTask(CgiEjv):
     @classmethod
     def get_invoices_for_refund_reversal(cls, partner):
         """Return invoices for refund reversal."""
-        # Refund_requested for credit card payments and REFUNDED for other payments.
-        refund_inv_statuses = (InvoiceStatus.REFUNDED.value, InvoiceStatus.REFUND_REQUESTED.value)
+        # REFUND_REQUESTED for credit card payments, CREDITED for AR and REFUNDED for other payments.
+        refund_inv_statuses = (InvoiceStatus.REFUNDED.value, InvoiceStatus.REFUND_REQUESTED.value,
+                               InvoiceStatus.CREDITED.value)
 
         invoices: List[InvoiceModel] = db.session.query(InvoiceModel) \
             .filter(InvoiceModel.invoice_status_code.in_(refund_inv_statuses)) \


### PR DESCRIPTION
…EDITED.

*Issue #:*
https://github.com/bcgov/entity/issues/18955 

*Description of changes:*
Invoices should go into CANCELLED, if they aren't created in CAS yet. Thus if they make it to PAID, but change into CREDITED before being disbursed - they should still be picked up by the disbursement job. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
