### PR TITLE
18763 - default statement settings for EFT

### DIFF
--- a/pay-api/src/pay_api/services/payment_account.py
+++ b/pay-api/src/pay_api/services/payment_account.py
@@ -30,14 +30,17 @@ from pay_api.models import EFTCredit as EFTCreditModel
 from pay_api.models import Invoice as InvoiceModel
 from pay_api.models import PaymentAccount as PaymentAccountModel
 from pay_api.models import PaymentAccountSchema
+from pay_api.models import StatementRecipients as StatementRecipientModel
 from pay_api.models import StatementSettings as StatementSettingsModel
 from pay_api.models import db
 from pay_api.services.cfs_service import CFSService
 from pay_api.services.distribution_code import DistributionCode
+from pay_api.services.oauth_service import OAuthService
 from pay_api.services.queue_publisher import publish_response
 from pay_api.services.statement_settings import StatementSettings
 from pay_api.utils.enums import (
-    CfsAccountStatus, InvoiceStatus, MessageType, PaymentMethod, PaymentSystem, StatementFrequency)
+    AuthHeaderType, CfsAccountStatus, ContentType, InvoiceStatus, MessageType, PaymentMethod, PaymentSystem,
+    StatementFrequency)
 from pay_api.utils.errors import Error
 from pay_api.utils.user_context import UserContext, user_context
 from pay_api.utils.util import (
@@ -344,6 +347,7 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
 
         PaymentAccount._save_account(account_request, account, is_sandbox)
         PaymentAccount._persist_default_statement_frequency(account.id)
+        PaymentAccount._check_and_update_statement_notifications(account)
 
         payment_account = PaymentAccount()
         payment_account._dao = account  # pylint: disable=protected-access
@@ -366,6 +370,44 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
 
             if statements_settings is not None and statements_settings.frequency != StatementFrequency.MONTHLY.value:
                 StatementSettings.update_statement_settings(auth_account_id, StatementFrequency.MONTHLY.value)
+                PaymentAccount._check_and_update_statement_notifications(payment_account)
+
+    @classmethod
+    @user_context
+    def _get_account_admin_users(cls, payment_account: PaymentAccountModel, **kwargs):
+        """Retrieve account admin users."""
+        return OAuthService.get(
+            current_app.config.get('AUTH_API_ENDPOINT') +
+            f'orgs/{payment_account.auth_account_id}/members?status=ACTIVE&roles=ADMIN',
+            kwargs['user'].bearer_token, AuthHeaderType.BEARER,
+            ContentType.JSON).json()
+
+    @classmethod
+    def _check_and_update_statement_notifications(cls, payment_account: PaymentAccountModel):
+        """Check and update statement notification and recipients."""
+        if payment_account.payment_method == PaymentMethod.EFT.value:
+            # Automatically enable notifications for EFT
+            payment_account.statement_notification_enabled = True
+            payment_account.save()
+
+            recipients: [StatementRecipientModel] = StatementRecipientModel. \
+                find_all_recipients_for_payment_id(payment_account.id)
+
+            # Auto-populate recipients with current account admins if there are currently none
+            if not recipients:
+                org_admins_response = cls._get_account_admin_users(payment_account)
+
+                members = org_admins_response.get('members') if org_admins_response.get('members', None) else []
+                for member in members:
+                    if user := member.get('user'):
+                        if contacts := user.get('contacts'):
+                            StatementRecipientModel(
+                                auth_user_id=user.get('id'),
+                                firstname=user.get('firstname'),
+                                lastname=user.get('lastname'),
+                                email=contacts[0].get('email'),
+                                payment_account_id=payment_account.id
+                            ).save()
 
     @classmethod
     def _save_account(cls, account_request: Dict[str, any], payment_account: PaymentAccountModel,

--- a/pay-api/tests/conftest.py
+++ b/pay-api/tests/conftest.py
@@ -376,3 +376,33 @@ def premium_user_mock(monkeypatch):
 def rest_call_mock(monkeypatch):
     """Mock rest_call_mock."""
     monkeypatch.setattr('pay_api.services.oauth_service.OAuthService.post', lambda *args, **kwargs: None)
+
+
+@pytest.fixture()
+def admin_users_mock(monkeypatch):
+    """Mock auth rest call to get org admins."""
+    def _get_account_admin_users(payment_account):
+        return {
+            'members': [
+                {
+                    'id': 4048,
+                    'membershipStatus': 'ACTIVE',
+                    'membershipTypeCode': 'ADMIN',
+                    'user': {
+                        'contacts': [
+                            {
+                                'email': 'test@test.com',
+                                'phone': '(250) 111-2222',
+                                'phoneExtension': ''
+                            }
+                        ],
+                        'firstname': 'FIRST',
+                        'id': 18,
+                        'lastname': 'LAST',
+                        'loginSource': 'BCSC'
+                    }
+                }
+            ]
+        }
+    monkeypatch.setattr('pay_api.services.payment_account.PaymentAccount._get_account_admin_users',
+                        _get_account_admin_users)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/18763

*Description of changes:*
- add logic to automatically enable statement notifications and recipients for EFT payment method

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
