### PR TITLE
19912- Updating partial refunds type enums

### DIFF
--- a/pay-api/src/pay_api/services/direct_pay_service.py
+++ b/pay-api/src/pay_api/services/direct_pay_service.py
@@ -322,7 +322,7 @@ class DirectPayService(PaymentSystemService, OAuthService):
             pli = PaymentLineItemModel.find_by_id(refund_line.payment_line_item_id)
             if not pli or refund_line.refund_amount < 0:
                 raise BusinessException(Error.INVALID_REQUEST)
-            is_service_fee = refund_line.refund_type == RefundsPartialType.SERVICE_FEE.value
+            is_service_fee = refund_line.refund_type == RefundsPartialType.SERVICE_FEES.value
             fee_distribution = DistributionCodeModel.find_by_id(pli.fee_distribution_id)
             if is_service_fee:
                 DirectPayService._validate_refund_amount(refund_line.refund_amount, pli.service_fees)

--- a/pay-api/src/pay_api/utils/enums.py
+++ b/pay-api/src/pay_api/utils/enums.py
@@ -285,8 +285,10 @@ class PatchActions(Enum):
 class RefundsPartialType(Enum):
     """Refund partial types."""
 
-    SERVICE_FEE = 'SERVICE_FEE'
-    OTHER_FEES = 'OTHER_FEES'
+    BASE_FEES = 'BASE_FEES'
+    FUTURE_EFFECTIVE_FEES = 'FUTURE_EFFECTIVE_FEES'
+    PRIORITY_FEES = 'PRIORITY_FEES'
+    SERVICE_FEES = 'SERVICE_FEES'
 
 
 class ReverseOperation(Enum):

--- a/pay-api/tests/unit/api/test_partial_refund.py
+++ b/pay-api/tests/unit/api/test_partial_refund.py
@@ -65,7 +65,7 @@ def test_create_refund(session, client, jwt, app, stan_server, monkeypatch):
     refund_amount = float(payment_line_items[0].filing_fees / 2)
     refund_revenue = [{'paymentLineItemId': payment_line_items[0].id,
                       'refundAmount': refund_amount,
-                       'refundType': RefundsPartialType.OTHER_FEES.value}
+                       'refundType': RefundsPartialType.BASE_FEES.value}
                       ]
 
     direct_pay_service = DirectPayService()
@@ -73,7 +73,7 @@ def test_create_refund(session, client, jwt, app, stan_server, monkeypatch):
     refund_partial = [
         RefundPartialLine(payment_line_item_id=payment_line_items[0].id,
                           refund_amount=Decimal(refund_amount),
-                          refund_type=RefundsPartialType.OTHER_FEES.value)
+                          refund_type=RefundsPartialType.BASE_FEES.value)
     ]
     with patch('pay_api.services.direct_pay_service.DirectPayService.get') as mock_get:
         mock_get.return_value.ok = True
@@ -102,7 +102,7 @@ def test_create_refund(session, client, jwt, app, stan_server, monkeypatch):
     assert refund.id is not None
     assert refund.payment_line_item_id == payment_line_items[0].id
     assert refund.refund_amount == refund_amount
-    assert refund.refund_type == RefundsPartialType.OTHER_FEES.value
+    assert refund.refund_type == RefundsPartialType.BASE_FEES.value
 
 
 def test_create_refund_fails(session, client, jwt, app, stan_server, monkeypatch):
@@ -132,7 +132,7 @@ def test_create_refund_fails(session, client, jwt, app, stan_server, monkeypatch
     refund_amount = float(payment_line_items[0].filing_fees / 2)
     refund_revenue = [{'paymentLineItemId': payment_line_items[0].id,
                        'refundAmount': refund_amount,
-                       'refundType': RefundsPartialType.OTHER_FEES.value}
+                       'refundType': RefundsPartialType.BASE_FEES.value}
                       ]
 
     token = jwt.create_jwt(get_claims(app_request=app, role=Role.SYSTEM.value), token_header)

--- a/pay-api/tests/unit/services/test_direct_pay_service.py
+++ b/pay-api/tests/unit/services/test_direct_pay_service.py
@@ -314,16 +314,16 @@ def _automated_refund_preparation():
     ('pay_pli_not_exist', [
         RefundPartialLine(payment_line_item_id=1,
                           refund_amount=1,
-                          refund_type=RefundsPartialType.OTHER_FEES.value)
+                          refund_type=RefundsPartialType.BASE_FEES.value)
     ]),
     ('pay_negative_refund_amount', [
         RefundPartialLine(payment_line_item_id=1,
                           refund_amount=-1,
-                          refund_type=RefundsPartialType.OTHER_FEES.value)]),
+                          refund_type=RefundsPartialType.BASE_FEES.value)]),
     ('pay_service_fee_too_high', [
         RefundPartialLine(payment_line_item_id=1,
                           refund_amount=3,
-                          refund_type=RefundsPartialType.SERVICE_FEE.value)]),
+                          refund_type=RefundsPartialType.SERVICE_FEES.value)]),
 ])
 def test_build_automated_refund_payload_validation(test_name, refund_partial):
     """Assert validations are working correctly for building refund payload."""
@@ -350,7 +350,7 @@ def test_build_automated_refund_payload_paybc_validation(test_name, has_exceptio
     refund_partial = [
         RefundPartialLine(payment_line_item_id=payment_line_item.id,
                           refund_amount=Decimal('3.1'),
-                          refund_type=RefundsPartialType.OTHER_FEES.value)
+                          refund_type=RefundsPartialType.BASE_FEES.value)
     ]
     direct_pay_service = DirectPayService()
     base_paybc_response = {


### PR DESCRIPTION
Added BASE_FEES, FUTURE_EFFECTIVE_FEES, and PRIORITY_FEES Removed OTHER_FEES

*Issue #:*
https://github.com/bcgov/entity/issues/19912

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
