### PR TITLE
20088 - Unlock associated accounts when paid with exact amount

### DIFF
--- a/pay-api/src/pay_api/services/__init__.py
+++ b/pay-api/src/pay_api/services/__init__.py
@@ -28,6 +28,7 @@ from .payment import Payment
 from .payment_service import PaymentService
 from .payment_transaction import PaymentTransaction as TransactionService
 from .receipt import Receipt as ReceiptService
+from .report_service import ReportService
 from .refund import RefundService
 from .statement import Statement
 from .statement_recipients import StatementRecipients

--- a/pay-api/tests/unit/services/test_statement.py
+++ b/pay-api/tests/unit/services/test_statement.py
@@ -453,28 +453,12 @@ def test_get_eft_statement_with_invoices(session):
 
         date_string_now = get_statement_date_string(datetime.now())
         expected_template_vars = {
-            'account': {
-                'accountType': 'PREMIUM',
-                'contact': {
-                    'city': 'Westbank',
-                    'country': 'CA',
-                    'created': '2020-05-14T17:33:04.315908+00:00',
-                    'createdBy': 'BCREGTEST Bena THIRTEEN',
-                    'modified': '2020-08-07T23:55:56.576008+00:00',
-                    'modifiedBy': 'BCREGTEST Bena THIRTEEN',
-                    'postalCode': 'V4T 2A5',
-                    'region': 'BC',
-                    'street': '66-2098 Boucherie Rd',
-                    'streetAdditional': 'First',
-                },
-                'id': payment_account.auth_account_id,
-                'name': 'Mock Account',
-                'paymentPreference': {
-                    'bcOnlineAccountId': '1234567890',
-                    'bcOnlineUserId': 'PB25020',
-                    'methodOfPayment': 'DRAWDOWN',
-                },
+            'statementSummary': {
+                'lastStatementTotal': 0,
+                'lastStatementPaidAmount': 0,
+                'latestStatementPaymentDate': None,
             },
+            'paymentTransactions': [],
             'invoices': [
                 {
                     'bcol_account': 'TEST',
@@ -553,7 +537,35 @@ def test_get_eft_statement_with_invoices(session):
                     'total': 50.0,
                 },
             ],
-            'paymentTransactions': [],
+            'total': {
+                'due': 250.0,
+                'fees': 250.0,
+                'paid': 0.0,
+                'serviceFees': 0.0,
+                'statutoryFees': 250.0,
+            },
+            'account': {
+                'accountType': 'PREMIUM',
+                'contact': {
+                    'city': 'Westbank',
+                    'country': 'CA',
+                    'created': '2020-05-14T17:33:04.315908+00:00',
+                    'createdBy': 'BCREGTEST Bena THIRTEEN',
+                    'modified': '2020-08-07T23:55:56.576008+00:00',
+                    'modifiedBy': 'BCREGTEST Bena THIRTEEN',
+                    'postalCode': 'V4T 2A5',
+                    'region': 'BC',
+                    'street': '66-2098 Boucherie Rd',
+                    'streetAdditional': 'First',
+                },
+                'id': payment_account.auth_account_id,
+                'name': 'Mock Account',
+                'paymentPreference': {
+                    'bcOnlineAccountId': '1234567890',
+                    'bcOnlineUserId': 'PB25020',
+                    'methodOfPayment': 'DRAWDOWN',
+                },
+            },
             'statement': {
                 'created_on': date_string_now,
                 'frequency': 'MONTHLY',
@@ -564,18 +576,6 @@ def test_get_eft_statement_with_invoices(session):
                 'is_overdue': False,
                 'notification_date': None,
                 'payment_methods': ['EFT']
-            },
-            'statementSummary': {
-                'lastStatementTotal': 0,
-                'lastStatementPaidAmount': 0,
-                'latestStatementPaymentDate': None,
-            },
-            'total': {
-                'due': 250.0,
-                'fees': 250.0,
-                'paid': 0.0,
-                'serviceFees': 0.0,
-                'statutoryFees': 250.0,
             }
         }
         expected_report_inputs = ReportRequest(report_name=report_name,

--- a/pay-api/tests/unit/services/test_statement.py
+++ b/pay-api/tests/unit/services/test_statement.py
@@ -453,12 +453,28 @@ def test_get_eft_statement_with_invoices(session):
 
         date_string_now = get_statement_date_string(datetime.now())
         expected_template_vars = {
-            'statementSummary': {
-                'lastStatementTotal': 0,
-                'lastStatementPaidAmount': 0,
-                'latestStatementPaymentDate': None,
+            'account': {
+                'accountType': 'PREMIUM',
+                'contact': {
+                    'city': 'Westbank',
+                    'country': 'CA',
+                    'created': '2020-05-14T17:33:04.315908+00:00',
+                    'createdBy': 'BCREGTEST Bena THIRTEEN',
+                    'modified': '2020-08-07T23:55:56.576008+00:00',
+                    'modifiedBy': 'BCREGTEST Bena THIRTEEN',
+                    'postalCode': 'V4T 2A5',
+                    'region': 'BC',
+                    'street': '66-2098 Boucherie Rd',
+                    'streetAdditional': 'First',
+                },
+                'id': payment_account.auth_account_id,
+                'name': 'Mock Account',
+                'paymentPreference': {
+                    'bcOnlineAccountId': '1234567890',
+                    'bcOnlineUserId': 'PB25020',
+                    'methodOfPayment': 'DRAWDOWN',
+                },
             },
-            'paymentTransactions': [],
             'invoices': [
                 {
                     'bcol_account': 'TEST',
@@ -537,35 +553,7 @@ def test_get_eft_statement_with_invoices(session):
                     'total': 50.0,
                 },
             ],
-            'total': {
-                'due': 250.0,
-                'fees': 250.0,
-                'paid': 0.0,
-                'serviceFees': 0.0,
-                'statutoryFees': 250.0,
-            },
-            'account': {
-                'accountType': 'PREMIUM',
-                'contact': {
-                    'city': 'Westbank',
-                    'country': 'CA',
-                    'created': '2020-05-14T17:33:04.315908+00:00',
-                    'createdBy': 'BCREGTEST Bena THIRTEEN',
-                    'modified': '2020-08-07T23:55:56.576008+00:00',
-                    'modifiedBy': 'BCREGTEST Bena THIRTEEN',
-                    'postalCode': 'V4T 2A5',
-                    'region': 'BC',
-                    'street': '66-2098 Boucherie Rd',
-                    'streetAdditional': 'First',
-                },
-                'id': payment_account.auth_account_id,
-                'name': 'Mock Account',
-                'paymentPreference': {
-                    'bcOnlineAccountId': '1234567890',
-                    'bcOnlineUserId': 'PB25020',
-                    'methodOfPayment': 'DRAWDOWN',
-                },
-            },
+            'paymentTransactions': [],
             'statement': {
                 'created_on': date_string_now,
                 'frequency': 'MONTHLY',
@@ -576,6 +564,18 @@ def test_get_eft_statement_with_invoices(session):
                 'is_overdue': False,
                 'notification_date': None,
                 'payment_methods': ['EFT']
+            },
+            'statementSummary': {
+                'lastStatementTotal': 0,
+                'lastStatementPaidAmount': 0,
+                'latestStatementPaymentDate': None,
+            },
+            'total': {
+                'due': 250.0,
+                'fees': 250.0,
+                'paid': 0.0,
+                'serviceFees': 0.0,
+                'statutoryFees': 250.0,
             }
         }
         expected_report_inputs = ReportRequest(report_name=report_name,

--- a/pay-queue/poetry.lock
+++ b/pay-queue/poetry.lock
@@ -1637,7 +1637,7 @@ python-dateutil = "2.9.0.post0"
 python-dotenv = "1.0.1"
 python-jose = "3.3.0"
 pytz = "2024.1"
-requests = "2.31.0"
+requests = "2.32.2"
 rsa = "4.9"
 sbc-common-components = {git = "https://github.com/bcgov/sbc-common-components.git", subdirectory = "python"}
 semver = "3.0.2"
@@ -1657,7 +1657,7 @@ werkzeug = "3.0.1"
 type = "git"
 url = "https://github.com/bcgov/sbc-pay.git"
 reference = "HEAD"
-resolved_reference = "24180c779947d10f985a4e7fe4321076dc4f2925"
+resolved_reference = "cb749fd5bd4f4cc578448d9cfb7f077fa9b6a395"
 subdirectory = "pay-api"
 
 [[package]]
@@ -2234,13 +2234,13 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.31.0"
+version = "2.32.2"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
-    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+    {file = "requests-2.32.2-py3-none-any.whl", hash = "sha256:fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c"},
+    {file = "requests-2.32.2.tar.gz", hash = "sha256:dd951ff5ecf3e3b3aa26b40703ba77495dab41da839ae72ef3c8e5d8e2433289"},
 ]
 
 [package.dependencies]

--- a/pay-queue/src/pay_queue/services/eft/eft_reconciliation.py
+++ b/pay-queue/src/pay_queue/services/eft/eft_reconciliation.py
@@ -451,6 +451,6 @@ def _unlock_associated_frozen_accounts(short_name_links: List[Dict]):
     """Unlock the frozen accounts."""
     # For each short name link, unlock the associated accounts
     for short_name_link in short_name_links:
-        payment_account: PaymentAccountModel = PaymentAccount.find_by_auth_account_id(
-            short_name_link['auth_account_id'])
+        auth_account_id = short_name_link['account_id']
+        payment_account: PaymentAccountModel = PaymentAccount.find_by_auth_account_id(auth_account_id)
         PaymentAccount.unlock_frozen_accounts(payment_account)

--- a/pay-queue/src/pay_queue/services/eft/eft_reconciliation.py
+++ b/pay-queue/src/pay_queue/services/eft/eft_reconciliation.py
@@ -430,16 +430,16 @@ def _pay_invoice(invoice: InvoiceModel, shortname_balance: Dict, short_name_link
                                                         payment_date=payment_date,
                                                         auto_save=True)
 
-    # If the payment amount is at least exactly the unpaid total, unlock associated accounts
-    if payable_amount == unpaid_total:
-        _unlock_associated_frozen_accounts(short_name_links=short_name_links,
-                                           payment=payment)
-
     db.session.add(payment)
     db.session.add(receipt)
 
     # Paid - update the shortname balance
     shortname_balance['balance'] -= payable_amount
+
+    # If the payment amount is at least exactly the unpaid total, unlock associated accounts
+    if payable_amount == unpaid_total:
+        _unlock_associated_frozen_accounts(short_name_links=short_name_links,
+                                           payment=payment)
 
 
 def _get_invoice_unpaid_total(invoice: InvoiceModel) -> Decimal:

--- a/pay-queue/src/pay_queue/services/eft/eft_reconciliation.py
+++ b/pay-queue/src/pay_queue/services/eft/eft_reconciliation.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """EFT reconciliation file."""
 from datetime import datetime
-from operator import and_
 from typing import Dict, List
 
 from _decimal import Decimal
@@ -28,7 +27,8 @@ from pay_api.models import Invoice as InvoiceModel
 from pay_api.models import PaymentAccount as PaymentAccountModel
 from pay_api.services.eft_service import EftService as EFTService
 from pay_api.services.eft_short_names import EFTShortnames
-from pay_api.utils.enums import EFTFileLineType, EFTProcessStatus, EFTShortnameStatus, InvoiceStatus, PaymentMethod
+from pay_api.services.payment_account import PaymentAccount
+from pay_api.utils.enums import EFTFileLineType, EFTProcessStatus, EFTShortnameStatus, PaymentMethod
 from sentry_sdk import capture_message
 
 from pay_queue.minio import get_object
@@ -255,7 +255,8 @@ def _process_eft_payments(shortname_balance: Dict, eft_file: EFTFileModel) -> bo
             # Find invoices to be paid
             invoices: List[InvoiceModel] = EFTShortnames.get_invoices_owing(auth_account_id)
             for invoice in invoices:
-                _pay_invoice(invoice=invoice, shortname_balance=shortname_balance[shortname])
+                _pay_invoice(invoice=invoice, shortname_balance=shortname_balance[shortname],
+                             short_name_links=shortname_links['items'])
 
         except Exception as e:  # NOQA pylint: disable=broad-exception-caught
             has_eft_transaction_errors = True
@@ -388,19 +389,6 @@ def _get_shortname(short_name: str) -> EFTShortnameModel:
     return eft_shortname
 
 
-def _get_invoices_owing(auth_account_id: str) -> [InvoiceModel]:
-    """Return invoices that have not been fully paid."""
-    unpaid_status = (InvoiceStatus.PARTIAL.value,
-                     InvoiceStatus.CREATED.value, InvoiceStatus.OVERDUE.value)
-    query = db.session.query(InvoiceModel) \
-        .join(PaymentAccountModel, and_(PaymentAccountModel.id == InvoiceModel.payment_account_id,
-                                        PaymentAccountModel.auth_account_id == auth_account_id)) \
-        .filter(InvoiceModel.invoice_status_code.in_(unpaid_status)) \
-        .order_by(InvoiceModel.created_on.asc())
-
-    return query.all()
-
-
 def _shortname_balance_as_dict(eft_transactions: List[EFTRecord]) -> Dict:
     """Create a dictionary mapping for shortname and total deposits from TDI17 file."""
     shortname_balance = {}
@@ -423,7 +411,7 @@ def _shortname_balance_as_dict(eft_transactions: List[EFTRecord]) -> Dict:
     return shortname_balance
 
 
-def _pay_invoice(invoice: InvoiceModel, shortname_balance: Dict):
+def _pay_invoice(invoice: InvoiceModel, shortname_balance: Dict, short_name_links: List[Dict]):
     """Pay for an invoice and update invoice state."""
     payment_date = shortname_balance.get('transaction_date') or datetime.now()
     balance = shortname_balance.get('balance')
@@ -441,6 +429,10 @@ def _pay_invoice(invoice: InvoiceModel, shortname_balance: Dict):
                                                         payment_date=payment_date,
                                                         auto_save=True)
 
+    # If the payment amount is at least exactly the unpaid total, unlock the user
+    if payable_amount == unpaid_total:
+        _unlock_associated_frozen_accounts(short_name_links=short_name_links)
+
     db.session.add(payment)
     db.session.add(receipt)
 
@@ -453,3 +445,12 @@ def _get_invoice_unpaid_total(invoice: InvoiceModel) -> Decimal:
     invoice_paid = invoice.paid or 0
 
     return invoice_total - invoice_paid
+
+
+def _unlock_associated_frozen_accounts(short_name_links: List[Dict]):
+    """Unlock the frozen accounts."""
+    # For each short name link, unlock the associated accounts
+    for short_name_link in short_name_links:
+        payment_account: PaymentAccountModel = PaymentAccount.find_by_auth_account_id(
+            short_name_link['auth_account_id'])
+        PaymentAccount.unlock_frozen_accounts(payment_account)

--- a/pay-queue/src/pay_queue/services/payment_reconciliations.py
+++ b/pay-queue/src/pay_queue/services/payment_reconciliations.py
@@ -195,9 +195,8 @@ def reconcile_payments(msg: Dict[str, any]):
         current_app.logger.info('File: %s has been processed or processing in progress. Skipping file. '
                                 'Removing this row will allow processing to be restarted.', file_name)
         return
-    else:
-        current_app.logger.info('Creating cas_settlement record for file: %s', file_name)
-        cas_settlement = _create_cas_settlement(file_name)
+    current_app.logger.info('Creating cas_settlement record for file: %s', file_name)
+    cas_settlement = _create_cas_settlement(file_name)
 
     file = get_object(minio_location, file_name)
     content = file.data.decode('utf-8-sig')


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/20088

*Description of changes:*
Unlocking overdue BCROS account when paid with exact amount

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
