### PR TITLE
20719- Interim Statements Settings Fix

### DIFF
--- a/jobs/payment-jobs/invoke_jobs.py
+++ b/jobs/payment-jobs/invoke_jobs.py
@@ -156,6 +156,7 @@ def run(job_name, argument=None):
 if __name__ == "__main__":
     print('----------------------------Scheduler Ran With Argument--', sys.argv[1])
     if (len(sys.argv) > 2):
-        run(sys.argv[1], sys.argv[2])
+        params = sys.argv[2:len(sys.argv)]
+        run(sys.argv[1], params)
     else:
         run(sys.argv[1])

--- a/jobs/payment-jobs/tasks/statement_task.py
+++ b/jobs/payment-jobs/tasks/statement_task.py
@@ -198,7 +198,6 @@ class StatementTask:  # pylint:disable=too-few-public-methods
     @classmethod
     def _filter_settings_by_override(cls, statement_settings, auth_account_id: str):
         """Return filtered Statement settings by payment account."""
-        if statement_settings:
-            return [settings
-                    for settings in statement_settings
-                    if settings.PaymentAccount.auth_account_id == auth_account_id]
+        return [settings
+                for settings in statement_settings
+                if settings.PaymentAccount.auth_account_id == auth_account_id]

--- a/jobs/payment-jobs/tasks/statement_task.py
+++ b/jobs/payment-jobs/tasks/statement_task.py
@@ -33,36 +33,43 @@ class StatementTask:  # pylint:disable=too-few-public-methods
     """Task to generate statements."""
 
     has_date_override: bool = False
+    has_account_override: bool = False
 
     @classmethod
-    def generate_statements(cls, date_override=None):
+    def generate_statements(cls, arguments=None):
         """Generate statements.
 
         Steps:
         1. Get all payment accounts and it's active statement settings.
         """
+        date_override = arguments[0] if arguments and len(arguments) > 0 else None
+        auth_account_override = arguments[1] if arguments and len(arguments) > 1 else None
+
         target_time = get_local_time(datetime.now()) if date_override is None \
             else datetime.strptime(date_override, '%Y-%m-%d') + timedelta(days=1)
         cls.has_date_override = date_override is not None
+        cls.has_account_override = auth_account_override is not None
         if date_override:
             current_app.logger.debug(f'Generating statements for: {date_override} using date override.')
+        if auth_account_override:
+            current_app.logger.debug(f'Generating statements for: {auth_account_override} using account override.')
         # If today is sunday - generate all weekly statements for pervious week
         # If today is month beginning - generate all monthly statements for previous month
         # For every day generate all daily statements for previous day
         generate_weekly = target_time.weekday() == 6  # Sunday is 6
         generate_monthly = target_time.day == 1
 
-        cls._generate_daily_statements(target_time)
+        cls._generate_daily_statements(target_time, auth_account_override)
         if generate_weekly:
-            cls._generate_weekly_statements(target_time)
+            cls._generate_weekly_statements(target_time, auth_account_override)
         if generate_monthly:
-            cls._generate_monthly_statements(target_time)
+            cls._generate_monthly_statements(target_time, auth_account_override)
 
         # Commit transaction
         db.session.commit()
 
     @classmethod
-    def _generate_daily_statements(cls, target_time: datetime):
+    def _generate_daily_statements(cls, target_time: datetime, account_override: str):
         """Generate daily statements for all accounts with settings to generate daily."""
         previous_day = get_previous_day(target_time)
         statement_settings = StatementSettingsModel.find_accounts_settings_by_frequency(previous_day,
@@ -74,10 +81,10 @@ class StatementTask:  # pylint:disable=too-few-public-methods
                 'endDate': previous_day.strftime('%Y-%m-%d')
             }
         }
-        cls._create_statement_records(search_filter, statement_settings)
+        cls._create_statement_records(search_filter, statement_settings, account_override)
 
     @classmethod
-    def _generate_weekly_statements(cls, target_time: datetime):
+    def _generate_weekly_statements(cls, target_time: datetime, account_override: str):
         """Generate weekly statements for all accounts with settings to generate weekly."""
         previous_day = get_previous_day(target_time)
         statement_settings = StatementSettingsModel.find_accounts_settings_by_frequency(previous_day,
@@ -91,10 +98,10 @@ class StatementTask:  # pylint:disable=too-few-public-methods
             }
         }
 
-        cls._create_statement_records(search_filter, statement_settings)
+        cls._create_statement_records(search_filter, statement_settings, account_override)
 
     @classmethod
-    def _generate_monthly_statements(cls, target_time: datetime):
+    def _generate_monthly_statements(cls, target_time: datetime, account_override: str):
         """Generate monthly statements for all accounts with settings to generate monthly."""
         previous_day = get_previous_day(target_time)
         statement_settings = StatementSettingsModel.find_accounts_settings_by_frequency(previous_day,
@@ -108,10 +115,10 @@ class StatementTask:  # pylint:disable=too-few-public-methods
             }
         }
 
-        cls._create_statement_records(search_filter, statement_settings)
+        cls._create_statement_records(search_filter, statement_settings, account_override)
 
     @classmethod
-    def _create_statement_records(cls, search_filter, statement_settings):
+    def _create_statement_records(cls, search_filter, statement_settings, account_override: str):
         statement_from = None
         statement_to = None
         if search_filter.get('dateFilter', None):
@@ -125,7 +132,12 @@ class StatementTask:  # pylint:disable=too-few-public-methods
             statement_from, statement_to = get_first_and_last_dates_of_month(
                 search_filter.get('monthFilter').get('month'), search_filter.get('monthFilter').get('year'))
             current_app.logger.debug(f'Statements for month: {statement_from.date()} to {statement_to.date()}')
-        auth_account_ids = [pay_account.auth_account_id for _, pay_account in statement_settings]
+        if cls.has_account_override:
+            auth_account_ids = [account_override]
+            statement_settings = cls._filter_settings_by_override(statement_settings, account_override)
+            current_app.logger.debug(f'Override Filtered to {len(statement_settings)} accounts to generate statements.')
+        else:
+            auth_account_ids = [pay_account.auth_account_id for _, pay_account in statement_settings]
         search_filter['authAccountIds'] = auth_account_ids
         # Force match on these methods where if the payment method is in matchPaymentMethods, the invoice payment method
         # must match the account payment method. Used for EFT so the statements only show EFT invoices and interim
@@ -136,15 +148,15 @@ class StatementTask:  # pylint:disable=too-few-public-methods
             cls._clean_up_old_statements(statement_settings, statement_from, statement_to)
         current_app.logger.debug('Inserting statements.')
         statements = [StatementModel(
-                frequency=setting.frequency,
-                statement_settings_id=setting.id,
-                payment_account_id=pay_account.id,
-                created_on=get_local_time(datetime.now()),
-                from_date=statement_from,
-                to_date=statement_to,
-                notification_status_code=NotificationStatus.PENDING.value
-                if pay_account.statement_notification_enabled is True and cls.has_date_override is False
-                else NotificationStatus.SKIP.value
+            frequency=setting.frequency,
+            statement_settings_id=setting.id,
+            payment_account_id=pay_account.id,
+            created_on=get_local_time(datetime.now()),
+            from_date=statement_from,
+            to_date=statement_to,
+            notification_status_code=NotificationStatus.PENDING.value
+            if pay_account.statement_notification_enabled is True and cls.has_date_override is False
+            else NotificationStatus.SKIP.value
         ) for setting, pay_account in statement_settings]
         # Return defaults which returns the id.
         db.session.bulk_save_objects(statements, return_defaults=True)
@@ -182,3 +194,11 @@ class StatementTask:  # pylint:disable=too-few-public-methods
         db.session.flush()
         delete_statement = delete(StatementModel).where(StatementModel.id.in_(remove_statements_ids))
         db.session.execute(delete_statement)
+
+    @classmethod
+    def _filter_settings_by_override(cls, statement_settings, auth_account_id: str):
+        """Return filtered Statement settings by payment account."""
+        if statement_settings:
+            return [settings
+                    for settings in statement_settings
+                    if settings.PaymentAccount.auth_account_id == auth_account_id]

--- a/jobs/payment-jobs/tests/jobs/test_generate_statements.py
+++ b/jobs/payment-jobs/tests/jobs/test_generate_statements.py
@@ -75,7 +75,7 @@ def test_statements(session):
 
     # Test date override.
     # Override computes for the target date, not the previous date like above.
-    StatementTask.generate_statements((datetime.utcnow() - timedelta(days=1)).strftime('%Y-%m-%d'))
+    StatementTask.generate_statements([(datetime.utcnow() - timedelta(days=1)).strftime('%Y-%m-%d')])
 
     statements = Statement.find_all_statements_for_account(auth_account_id=bcol_account.auth_account_id, page=1,
                                                            limit=100)
@@ -180,7 +180,7 @@ def test_bcol_weekly_to_eft_statement(session):
     assert monthly_invoice is not None
 
     # Regenerate monthly statement using date override - it will clean up the previous empty monthly statement first
-    StatementTask.generate_statements((generate_date - timedelta(days=1)).strftime('%Y-%m-%d'))
+    StatementTask.generate_statements([(generate_date - timedelta(days=1)).strftime('%Y-%m-%d')])
 
     statements = Statement.find_all_statements_for_account(auth_account_id=account.auth_account_id, page=1,
                                                            limit=100)
@@ -258,7 +258,7 @@ def test_bcol_monthly_to_eft_statement(session):
     assert monthly_invoice is not None
 
     # Regenerate monthly statement using date override - it will clean up the previous empty monthly statement first
-    StatementTask.generate_statements((generate_date - timedelta(days=1)).strftime('%Y-%m-%d'))
+    StatementTask.generate_statements([(generate_date - timedelta(days=1)).strftime('%Y-%m-%d')])
 
     statements = Statement.find_all_statements_for_account(auth_account_id=account.auth_account_id, page=1,
                                                            limit=100)

--- a/pay-api/src/pay_api/services/payment_account.py
+++ b/pay-api/src/pay_api/services/payment_account.py
@@ -394,8 +394,7 @@ class PaymentAccount():  # pylint: disable=too-many-instance-attributes, too-man
         if payment_account and payment_account.payment_method == PaymentMethod.EFT.value:
             # EFT payment method should automatically set statement frequency to MONTHLY
             auth_account_id = str(payment_account.auth_account_id)
-            statements_settings: StatementSettingsModel = StatementSettingsModel\
-                .find_active_settings(auth_account_id, datetime.today())
+            statements_settings: StatementSettingsModel = StatementSettingsModel.find_latest_settings(auth_account_id)
 
             if statements_settings is not None and statements_settings.frequency != StatementFrequency.MONTHLY.value:
                 StatementSettings.update_statement_settings(auth_account_id, StatementFrequency.MONTHLY.value)

--- a/pay-api/src/pay_api/version.py
+++ b/pay-api/src/pay_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.21.0'  # pylint: disable=invalid-name
+__version__ = '1.21.1'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/20719

*Description of changes:*
- fixes incorrect date ranges generated for interim statement settings
- Add ability to generate statements filtered by account. This allows us to generate a monthly statement early on a specific account without affecting other accounts


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
