### PR TITLE
Cast to numeric

### DIFF
--- a/pay-api/src/pay_api/models/routing_slip.py
+++ b/pay-api/src/pay_api/models/routing_slip.py
@@ -21,8 +21,8 @@ from typing import Dict, List
 import pytz
 from flask import current_app
 from marshmallow import fields
-from sqlalchemy import ForeignKey, func
-from sqlalchemy.orm import contains_eager, lazyload, load_only, relationship
+from sqlalchemy import ForeignKey, Numeric, func
+from sqlalchemy.orm import cast, contains_eager, lazyload, load_only, relationship
 
 from pay_api.utils.constants import DT_SHORT_FORMAT
 from pay_api.utils.enums import PaymentMethod, RoutingSlipStatus
@@ -190,7 +190,7 @@ class RoutingSlip(Audit):  # pylint: disable=too-many-instance-attributes
             query = query.filter(RoutingSlip.total == total_amount)
 
         if remaining_amount := search_filter.get('remainingAmount', None):
-            query = query.filter(RoutingSlip.remaining_amount == remaining_amount.replace('$', ''))
+            query = query.filter(RoutingSlip.remaining_amount == cast(remaining_amount.replace('$', ''), Numeric))
 
         query = cls._add_date_filter(query, search_filter)
 

--- a/pay-api/src/pay_api/models/routing_slip.py
+++ b/pay-api/src/pay_api/models/routing_slip.py
@@ -21,8 +21,8 @@ from typing import Dict, List
 import pytz
 from flask import current_app
 from marshmallow import fields
-from sqlalchemy import ForeignKey, Numeric, func
-from sqlalchemy.orm import cast, contains_eager, lazyload, load_only, relationship
+from sqlalchemy import ForeignKey, Numeric, cast, func
+from sqlalchemy.orm import contains_eager, lazyload, load_only, relationship
 
 from pay_api.utils.constants import DT_SHORT_FORMAT
 from pay_api.utils.enums import PaymentMethod, RoutingSlipStatus


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).

Fixes:

sqlalchemy.exc.ProgrammingError: (pg8000.dbapi.ProgrammingError) {'S': 'ERROR', 'V': 'ERROR', 'C': '42883', 'M': 'operator does not exist: numeric = character varying', 'H': 'No operator matches the given name and argument types. You might need to add explicit type casts.', 'P': '1404', 'F': 'parse_oper.c', 'L': '647', 'R': 'op_error'}
