### PR TITLE
Add in composite index for invoice_status_code and payment_account_id

### DIFF
--- a/pay-api/migrations/versions/2024_07_16_f98666d9809a_.py
+++ b/pay-api/migrations/versions/2024_07_16_f98666d9809a_.py
@@ -1,0 +1,25 @@
+"""Add in composite index for invoice_status_code and payment_account_id so our payment blocker check is fast.
+
+Revision ID: f98666d9809a
+Revises: f921d5e32835
+Create Date: 2024-07-16 14:26:07.469225
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'f98666d9809a'
+down_revision = 'f921d5e32835'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('invoices', schema=None) as batch_op:
+        batch_op.create_index('idx_invoice_invoice_status_code_payment_account_idx', ['payment_account_id', 'invoice_status_code'], unique=False)
+
+def downgrade():
+    with op.batch_alter_table('invoices', schema=None) as batch_op:
+        batch_op.drop_index('idx_invoice_invoice_status_code_payment_account_idx')

--- a/pay-api/src/pay_api/models/invoice.py
+++ b/pay-api/src/pay_api/models/invoice.py
@@ -118,6 +118,10 @@ class Invoice(Audit):  # pylint: disable=too-many-instance-attributes
     references = relationship('InvoiceReference', lazy='joined')
     corp_type = relationship('CorpType', foreign_keys=[corp_type_code], lazy='select', innerjoin=True)
 
+    __table_args__ = (
+        db.Index('idx_invoice_invoice_status_code_payment_account_idx', payment_account_id, invoice_status_code),
+    )
+
     @classmethod
     def update_invoices_for_revenue_updates(cls, fee_distribution_id: int):
         """Find and update all invoices using the distribution id."""


### PR DESCRIPTION
This brought down the time from 9s -> 74ms

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
