### PR TITLE
22480 - Skip version tables in migrations

### DIFF
--- a/pay-api/migrations/alembic.ini
+++ b/pay-api/migrations/alembic.ini
@@ -4,11 +4,11 @@
 script_location = .
 # template used to generate migration files
 file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(rev)s_%%(slug)s
-
+# Will remove these after we confirm the tables are working as expected on PROD.
+exclude_tables = account_fees_version,activity,payment_accounts_version,refunds_partial_version,distribution_codes_version,eft_short_names_version,transaction,cfs_accounts_version
 # set to 'true' to run the environment during
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
-
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/22480

*Description of changes:*
 Add in handling that skips the verison tables for now

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
