### PR TITLE
22625 - Move to 1 month + 15 days instead of 1 month for overdue

### DIFF
--- a/.github/workflows/ftp-poller-ci.yml
+++ b/.github/workflows/ftp-poller-ci.yml
@@ -82,6 +82,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install docker-compose
+        run: |
+          sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose version
       - name: Install dependencies
         run: |
           make setup

--- a/.github/workflows/pay-api-ci.yml
+++ b/.github/workflows/pay-api-ci.yml
@@ -93,6 +93,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install docker-compose
+        run: |
+          sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose version
       - name: Install dependencies
         run: |
           make setup

--- a/.github/workflows/pay-queue-ci.yml
+++ b/.github/workflows/pay-queue-ci.yml
@@ -93,6 +93,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install docker-compose
+        run: |
+          sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose version
       - name: Install dependencies
         run: |
           make setup

--- a/.github/workflows/payment-jobs-ci.yml
+++ b/.github/workflows/payment-jobs-ci.yml
@@ -85,6 +85,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install docker-compose
+        run: |
+          sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
       - name: Install dependencies
         run: |
           make setup

--- a/.github/workflows/payment-jobs-ci.yml
+++ b/.github/workflows/payment-jobs-ci.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose version
       - name: Install dependencies
         run: |
           make setup

--- a/jobs/payment-jobs/poetry.lock
+++ b/jobs/payment-jobs/poetry.lock
@@ -1999,9 +1999,9 @@ werkzeug = "3.0.1"
 
 [package.source]
 type = "git"
-url = "https://github.com/bcgov/sbc-pay.git"
-reference = "HEAD"
-resolved_reference = "de5eaa066f3e42188138d6919e3bb257885a596c"
+url = "https://github.com/seeker25/sbc-pay.git"
+reference = "overdue_date_fix_"
+resolved_reference = "5d9a69ccac6969e786fd9bd86e949ced88333aca"
 subdirectory = "pay-api"
 
 [[package]]
@@ -3141,4 +3141,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "3ec0b51675efd0cf2d4bb86d2c636f4b147d554e6dd34d02195adbe7e1874acf"
+content-hash = "fcdbf0a90081b39d31af34ca6dfb926193bfa8373b6a02a32017533c283435c8"

--- a/jobs/payment-jobs/poetry.lock
+++ b/jobs/payment-jobs/poetry.lock
@@ -2001,7 +2001,7 @@ werkzeug = "3.0.1"
 type = "git"
 url = "https://github.com/seeker25/sbc-pay.git"
 reference = "overdue_date_fix_"
-resolved_reference = "5d9a69ccac6969e786fd9bd86e949ced88333aca"
+resolved_reference = "e63a8c1366fc0e736390ca3d3e6a472c092677b1"
 subdirectory = "pay-api"
 
 [[package]]

--- a/jobs/payment-jobs/poetry.lock
+++ b/jobs/payment-jobs/poetry.lock
@@ -2001,7 +2001,7 @@ werkzeug = "3.0.1"
 type = "git"
 url = "https://github.com/bcgov/sbc-pay.git"
 reference = "HEAD"
-resolved_reference = "012af273fe5ea47368f9c3ff9f0fe7e253e211dc"
+resolved_reference = "de5eaa066f3e42188138d6919e3bb257885a596c"
 subdirectory = "pay-api"
 
 [[package]]

--- a/jobs/payment-jobs/pyproject.toml
+++ b/jobs/payment-jobs/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-pay-api = {git = "https://github.com/bcgov/sbc-pay.git", subdirectory = "pay-api"}
+pay-api = {git = "https://github.com/seeker25/sbc-pay.git", branch = "overdue_date_fix_", subdirectory = "pay-api"}
 gunicorn = "^21.2.0"
 flask = "^3.0.2"
 flask-sqlalchemy = "^3.1.1"

--- a/jobs/payment-jobs/tasks/statement_due_task.py
+++ b/jobs/payment-jobs/tasks/statement_due_task.py
@@ -153,8 +153,13 @@ class StatementDueTask:   # pylint: disable=too-few-public-methods
         if invoice is None:
             return None, None
 
-        day_before_invoice_overdue = (invoice.overdue_date - timedelta(days=1)).date()
-        seven_days_before_invoice_due = day_before_invoice_overdue - timedelta(days=7)
+        # 1. EFT Invoice created between or on January 1st <-> January 31st
+        # 2. Statement Day Feburary 1st
+        # 3. 7 day reminder Feb 21th ( due date - 7)
+        # 4. Final reminder Feb 28th (due date client should be told to pay by this time)
+        # 5. Overdue Date and account locked March 15th
+        day_before_invoice_overdue = (invoice.overdue_date - timedelta(days=1 + 15)).date()
+        seven_days_before_invoice_due = day_before_invoice_overdue - timedelta(days=7 + 15)
         now_date = datetime.now(tz=timezone.utc).date()
 
         if invoice.invoice_status_code == InvoiceStatus.OVERDUE.value:

--- a/jobs/payment-jobs/tasks/statement_due_task.py
+++ b/jobs/payment-jobs/tasks/statement_due_task.py
@@ -154,7 +154,7 @@ class StatementDueTask:   # pylint: disable=too-few-public-methods
             return None, None
 
         # 1. EFT Invoice created between or on January 1st <-> January 31st
-        # 2. Statement Day Feburary 1st
+        # 2. Statement Day February 1st
         # 3. 7 day reminder Feb 21th ( due date - 7)
         # 4. Final reminder Feb 28th (due date client should be told to pay by this time)
         # 5. Overdue Date and account locked March 15th

--- a/jobs/payment-jobs/tasks/statement_due_task.py
+++ b/jobs/payment-jobs/tasks/statement_due_task.py
@@ -158,17 +158,17 @@ class StatementDueTask:   # pylint: disable=too-few-public-methods
         # 3. 7 day reminder Feb 21th ( due date - 7)
         # 4. Final reminder Feb 28th (due date client should be told to pay by this time)
         # 5. Overdue Date and account locked March 15th
-        day_before_invoice_overdue = (invoice.overdue_date - timedelta(days=1 + 15)).date()
-        seven_days_before_invoice_due = day_before_invoice_overdue - timedelta(days=7 + 15)
+        day_invoice_due = (invoice.overdue_date - timedelta(days=15)).date()
+        seven_days_before_invoice_due = day_invoice_due - timedelta(days=7)
         now_date = datetime.now(tz=timezone.utc).date()
 
         if invoice.invoice_status_code == InvoiceStatus.OVERDUE.value:
-            return StatementNotificationAction.OVERDUE, day_before_invoice_overdue
-        if day_before_invoice_overdue == now_date:
-            return StatementNotificationAction.DUE, day_before_invoice_overdue
+            return StatementNotificationAction.OVERDUE, day_invoice_due
+        if day_invoice_due == now_date:
+            return StatementNotificationAction.DUE, day_invoice_due
         if seven_days_before_invoice_due == now_date:
-            return StatementNotificationAction.REMINDER, day_before_invoice_overdue
-        return None, day_before_invoice_overdue
+            return StatementNotificationAction.REMINDER, day_invoice_due
+        return None, day_invoice_due
 
     @classmethod
     def _determine_recipient_emails(cls, statement: StatementRecipientsModel) -> str:

--- a/jobs/payment-jobs/tasks/statement_due_task.py
+++ b/jobs/payment-jobs/tasks/statement_due_task.py
@@ -58,10 +58,12 @@ class StatementDueTask:   # pylint: disable=too-few-public-methods
     @classmethod
     def _update_invoice_overdue_status(cls):
         """Update the status of any invoices that are overdue."""
+        # Needs to be non timezone aware.
+        now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
         query = db.session.query(InvoiceModel) \
             .filter(InvoiceModel.payment_method_code == PaymentMethod.EFT.value,
                     InvoiceModel.overdue_date.isnot(None),
-                    InvoiceModel.overdue_date <= datetime.now(tz=timezone.utc),
+                    InvoiceModel.overdue_date <= now,
                     InvoiceModel.invoice_status_code.in_(cls.unpaid_status))
         query.update({InvoiceModel.invoice_status_code: InvoiceStatus.OVERDUE.value}, synchronize_session='fetch')
         db.session.commit()

--- a/jobs/payment-jobs/tests/jobs/test_statement_due_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_statement_due_task.py
@@ -106,6 +106,7 @@ def test_send_unpaid_statement_notification(setup, session, test_name, freeze_ti
 
     now = current_local_time().replace(hour=1)
     _, last_day = get_first_and_last_dates_of_month(now.month, now.year)
+    last_day = last_day + timedelta(hours=8) # 8 Hours should get us into the correct day.
 
     # Generate statement for previous month - freeze time to the 1st of the current month
     with freeze_time(current_local_time().replace(day=1, hour=1)):

--- a/jobs/payment-jobs/tests/jobs/test_statement_due_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_statement_due_task.py
@@ -106,7 +106,7 @@ def test_send_unpaid_statement_notification(setup, session, test_name, freeze_ti
 
     now = current_local_time().replace(hour=1)
     _, last_day = get_first_and_last_dates_of_month(now.month, now.year)
-    last_day = last_day + timedelta(hours=8)  # 8 Hours should get us into the correct day.
+    last_day = last_day.replace(hour=8)  # 8 Hours should get us into the correct day.
 
     # Generate statement for previous month - freeze time to the 1st of the current month
     with freeze_time(current_local_time().replace(day=1, hour=1)):
@@ -152,7 +152,7 @@ def test_unpaid_statement_notification_not_sent(setup, session):
 
 def test_overdue_invoices_updated(setup, session):
     """Assert invoices are transitioned to overdue status."""
-    invoice_date = current_local_time() + relativedelta(months=-2, day=5, hours=1)
+    invoice_date = current_local_time() - relativedelta(months=2, days=15)
     account, invoice, _, \
         _, _ = create_test_data(PaymentMethod.EFT.value,
                                 invoice_date,

--- a/jobs/payment-jobs/tests/jobs/test_statement_due_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_statement_due_task.py
@@ -80,10 +80,15 @@ def create_test_data(payment_method_code: str, payment_date: datetime,
     return account, invoice, inv_ref, statement_recipient, statement_settings
 
 
+# 1. EFT Invoice created between or on January 1st <-> January 31st
+# 2. Statement Day Feburary 1st
+# 3. 7 day reminder Feb 21th ( due date - 7)
+# 4. Final reminder Feb 28th (due date client should be told to pay by this time)
+# 5. Overdue Date and account locked March 15th
 @pytest.mark.parametrize('test_name, freeze_time_offset, action', [
     ('reminder', timedelta(days=-7), StatementNotificationAction.REMINDER),
     ('due', timedelta(days=0), StatementNotificationAction.DUE),
-    ('overdue', timedelta(days=7), StatementNotificationAction.OVERDUE)
+    ('overdue', timedelta(days=15), StatementNotificationAction.OVERDUE)
 ])
 def test_send_unpaid_statement_notification(setup, session, test_name, freeze_time_offset, action):
     """Assert payment reminder event is being sent."""

--- a/jobs/payment-jobs/tests/jobs/test_statement_due_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_statement_due_task.py
@@ -81,7 +81,7 @@ def create_test_data(payment_method_code: str, payment_date: datetime,
 
 
 # 1. EFT Invoice created between or on January 1st <-> January 31st
-# 2. Statement Day Feburary 1st
+# 2. Statement Day February 1st
 # 3. 7 day reminder Feb 21th ( due date - 7)
 # 4. Final reminder Feb 28th (due date client should be told to pay by this time)
 # 5. Overdue Date and account locked March 15th

--- a/jobs/payment-jobs/tests/jobs/test_statement_due_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_statement_due_task.py
@@ -106,7 +106,7 @@ def test_send_unpaid_statement_notification(setup, session, test_name, freeze_ti
 
     now = current_local_time().replace(hour=1)
     _, last_day = get_first_and_last_dates_of_month(now.month, now.year)
-    last_day = last_day + timedelta(hours=8) # 8 Hours should get us into the correct day.
+    last_day = last_day + timedelta(hours=8)  # 8 Hours should get us into the correct day.
 
     # Generate statement for previous month - freeze time to the 1st of the current month
     with freeze_time(current_local_time().replace(day=1, hour=1)):

--- a/pay-admin/poetry.lock
+++ b/pay-admin/poetry.lock
@@ -2584,13 +2584,13 @@ tornado = ["tornado (>=5)"]
 
 [[package]]
 name = "setuptools"
-version = "71.1.0"
+version = "72.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-71.1.0-py3-none-any.whl", hash = "sha256:33874fdc59b3188304b2e7c80d9029097ea31627180896fb549c578ceb8a0855"},
-    {file = "setuptools-71.1.0.tar.gz", hash = "sha256:032d42ee9fb536e33087fb66cac5f840eb9391ed05637b3f2a76a7c8fb477936"},
+    {file = "setuptools-72.1.0-py3-none-any.whl", hash = "sha256:5a03e1860cf56bb6ef48ce186b0e557fdba433237481a9a625176c2831be15d1"},
+    {file = "setuptools-72.1.0.tar.gz", hash = "sha256:8d243eff56d095e5817f796ede6ae32941278f542e0f941867cc05ae52b162ec"},
 ]
 
 [package.extras]
@@ -3010,4 +3010,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "5f3151b030aa322511662aa8c0cfead2ba10483304e00665bd4a9d32eac1cc17"
+content-hash = "cafbee8ddf737b304fdbc944fd77620fddb9c4d375ee20236d0cf4e4db1abfc0"

--- a/pay-admin/pyproject.toml
+++ b/pay-admin/pyproject.toml
@@ -21,6 +21,7 @@ itsdangerous = "^2.1.2"
 jinja2 = "^3.1.3"
 pay-api = {git = "https://github.com/bcgov/sbc-pay.git", branch = "pay-admin-tweaks", subdirectory = "pay-api"}
 flask-session = {extras = ["filesystem"], version = "^0.8.0"}
+setuptools = "^72.1.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pay-api/src/pay_api/models/invoice.py
+++ b/pay-api/src/pay_api/models/invoice.py
@@ -42,7 +42,7 @@ def determine_overdue_date(context):
     """Determine the overdue date with the correct time offset."""
     created_on = context.get_current_parameters()['created_on']
     target_date = created_on.date() + relativedelta(months=2,
-                                                    day=1)
+                                                    day=15)
     target_datetime = datetime.combine(target_date, datetime.min.time())
     # Correct for daylight savings.
     hours = target_datetime.astimezone(pytz.timezone('America/Vancouver')).utcoffset().total_seconds() / 60 / 60

--- a/pay-api/src/pay_api/utils/util.py
+++ b/pay-api/src/pay_api/utils/util.py
@@ -18,7 +18,7 @@ A simple decorator to add the options method to a Request Class.
 """
 import ast
 import calendar
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict
 from decimal import Decimal
 from urllib.parse import parse_qsl
@@ -97,7 +97,7 @@ def get_week_start_and_end_date(target_date: datetime = datetime.now(), index: i
 
 def get_first_and_last_dates_of_month(month: int, year: int):
     """Return first and last dates for a given month and year."""
-    start_date = datetime.now().replace(day=1, year=year, month=month)
+    start_date = datetime.now(tz=timezone.utc).replace(day=1, year=year, month=month)
     end_date = start_date.replace(day=calendar.monthrange(year=year, month=month)[1])
     return start_date, end_date
 

--- a/pay-api/tests/unit/models/test_invoice.py
+++ b/pay-api/tests/unit/models/test_invoice.py
@@ -77,11 +77,11 @@ def test_payments_marked_for_delete(session):
 
 
 @pytest.mark.parametrize('test_name, created_on, overdue_date', [
-    ('March - PST - edge', datetime(2024, 1, 1, 8), datetime(2024, 3, 15, 8, 0, 0)),
+    ('March - PDT - edge', datetime(2024, 1, 1, 8), datetime(2024, 3, 15, 7, 0, 0)),
     ('April - PDT - edge', datetime(2024, 2, 1, 8), datetime(2024, 4, 15, 7, 0, 0)),
-    ('November - PDT - edge', datetime(2024, 9, 1, 8), datetime(2024, 11, 15, 7, 0, 0)),
+    ('November - PST - edge', datetime(2024, 9, 1, 8), datetime(2024, 11, 15, 8, 0, 0)),
     ('December - PST - edge', datetime(2024, 10, 1, 8), datetime(2024, 12, 15, 8, 0, 0)),
-    ('End of the month invoice creation', datetime(2024, 1, 31, 8), datetime(2024, 3, 15, 8, 0, 0)),
+    ('End of the month invoice creation', datetime(2024, 1, 31, 8), datetime(2024, 3, 15, 7, 0, 0)),
     ('Beginning of month invoice creation', datetime(2023, 12, 1, 8), datetime(2024, 2, 15, 8, 0, 0)),
 ])
 def test_overdue_date(session, test_name, created_on, overdue_date):

--- a/pay-api/tests/unit/models/test_invoice.py
+++ b/pay-api/tests/unit/models/test_invoice.py
@@ -40,7 +40,7 @@ def test_invoice(session):
 
     # assert overdue default is set
     assert invoice.overdue_date is not None
-    assert invoice.overdue_date.date() == (datetime.now(tz=timezone.utc) + relativedelta(months=2, day=1)).date()
+    assert invoice.overdue_date.date() == (datetime.now(tz=timezone.utc) + relativedelta(months=2, day=15)).date()
 
 
 def test_invoice_find_by_id(session):
@@ -77,10 +77,12 @@ def test_payments_marked_for_delete(session):
 
 
 @pytest.mark.parametrize('test_name, created_on, overdue_date', [
-    ('March - PST - edge', datetime(2024, 1, 1, 8), datetime(2024, 3, 1, 8, 0, 0)),
-    ('April - PDT - edge', datetime(2024, 2, 1, 8), datetime(2024, 4, 1, 7, 0, 0)),
-    ('November - PDT - edge', datetime(2024, 9, 1, 8), datetime(2024, 11, 1, 7, 0, 0)),
-    ('December - PST - edge', datetime(2024, 10, 1, 8), datetime(2024, 12, 1, 8, 0, 0))
+    ('March - PST - edge', datetime(2024, 1, 1, 8), datetime(2024, 3, 15, 8, 0, 0)),
+    ('April - PDT - edge', datetime(2024, 2, 1, 8), datetime(2024, 4, 15, 7, 0, 0)),
+    ('November - PDT - edge', datetime(2024, 9, 1, 8), datetime(2024, 11, 15, 7, 0, 0)),
+    ('December - PST - edge', datetime(2024, 10, 1, 8), datetime(2024, 12, 15, 8, 0, 0)),
+    ('End of the month invoice creation', datetime(2024, 1, 31, 8), datetime(2024, 3, 15, 8, 0, 0)),
+    ('Beginning of month invoice creation', datetime(2023, 12, 1, 8), datetime(2024, 2, 15, 8, 0, 0)),
 ])
 def test_overdue_date(session, test_name, created_on, overdue_date):
     """Test overdue date to make sure it's right TZ."""


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/22625

*Description of changes:*
EFT Invoice created on January 1st -> Statement Day Feburary 1st -> Client asked to pay by Feburary 28th -> overdue date March 15th
EFT Invoice created on January 31st -> Statement Day Feburary 1st -> Client asked to pay by Feburary 28th -> overdue date March 15th

After the statement has been issued:
7 day reminder = Feb 21 ( due date - 7)
final reminder = Feb 28 (due date)
overdue/account lock email = March 15 - SBC finance etc. CC'd / Kaine CC'd

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
