### PR TITLE
Use datetime.now(tz=timezone.utc) instead of datetime.today

### DIFF
--- a/jobs/payment-jobs/tasks/cfs_create_account_task.py
+++ b/jobs/payment-jobs/tasks/cfs_create_account_task.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Task to create CFS account offline."""
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict
 
 from flask import current_app
@@ -156,7 +156,7 @@ class CreateAccountTask:  # pylint: disable=too-few-public-methods
 
         # If the account has an activation time set it should have PENDING_PAD_ACTIVATION status.
         is_account_in_pad_confirmation_period = pay_account.pad_activation_date is not None and \
-            pay_account.pad_activation_date > datetime.today()
+            pay_account.pad_activation_date > datetime.now(tz=timezone.utc).replace(tzinfo=None)
         pending_account.status = CfsAccountStatus.PENDING_PAD_ACTIVATION.value if \
             is_account_in_pad_confirmation_period else CfsAccountStatus.ACTIVE.value
         pending_account.save()

--- a/jobs/payment-jobs/tasks/ejv_partner_distribution_task.py
+++ b/jobs/payment-jobs/tasks/ejv_partner_distribution_task.py
@@ -55,7 +55,9 @@ class EjvPartnerDistributionTask(CgiEjv):
     @staticmethod
     def get_invoices_for_disbursement(partner):
         """Return invoices for disbursement. Used by EJV and AP."""
-        disbursement_date = datetime.today() - timedelta(days=current_app.config.get('DISBURSEMENT_DELAY_IN_DAYS'))
+        disbursement_date = datetime.now(tz=timezone.utc) - \
+            timedelta(days=current_app.config.get(
+                'DISBURSEMENT_DELAY_IN_DAYS'))
         invoices: List[InvoiceModel] = db.session.query(InvoiceModel) \
             .filter(InvoiceModel.invoice_status_code == InvoiceStatus.PAID.value) \
             .filter(

--- a/jobs/payment-jobs/tasks/ejv_partner_distribution_task.py
+++ b/jobs/payment-jobs/tasks/ejv_partner_distribution_task.py
@@ -55,7 +55,7 @@ class EjvPartnerDistributionTask(CgiEjv):
     @staticmethod
     def get_invoices_for_disbursement(partner):
         """Return invoices for disbursement. Used by EJV and AP."""
-        disbursement_date = datetime.now(tz=timezone.utc) - \
+        disbursement_date = datetime.now(tz=timezone.utc).replace(tzinfo=None) - \
             timedelta(days=current_app.config.get(
                 'DISBURSEMENT_DELAY_IN_DAYS'))
         invoices: List[InvoiceModel] = db.session.query(InvoiceModel) \

--- a/jobs/payment-jobs/tasks/unpaid_invoice_notify_task.py
+++ b/jobs/payment-jobs/tasks/unpaid_invoice_notify_task.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Task to notify user for any outstanding invoice for online banking."""
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from flask import current_app
 from pay_api.models import CfsAccount as CfsAccountModel
@@ -50,7 +50,7 @@ class UnpaidInvoiceNotifyTask:  # pylint:disable=too-few-public-methods
         """
         unpaid_status = (
             InvoiceStatus.SETTLEMENT_SCHEDULED.value, InvoiceStatus.PARTIAL.value, InvoiceStatus.CREATED.value)
-        notification_date = datetime.today() - timedelta(days=current_app.config.get('NOTIFY_AFTER_DAYS'))
+        notification_date = datetime.now(tz=timezone.utc) - timedelta(days=current_app.config.get('NOTIFY_AFTER_DAYS'))
         # Get distinct accounts with pending invoices for that exact day
         notification_pending_accounts = db.session.query(InvoiceModel.payment_account_id).distinct().filter(and_(
             InvoiceModel.invoice_status_code.in_(unpaid_status),

--- a/jobs/payment-jobs/tests/jobs/factory.py
+++ b/jobs/payment-jobs/tests/jobs/factory.py
@@ -158,7 +158,7 @@ def factory_create_pad_account(auth_account_id='1234', bank_number='001', bank_b
                                status=CfsAccountStatus.PENDING.value, payment_method=PaymentMethod.PAD.value,
                                confirmation_period: int = 3):
     """Return Factory."""
-    date_after_wait_period = datetime.today() + timedelta(confirmation_period)
+    date_after_wait_period = datetime.now(tz=timezone.utc) + timedelta(confirmation_period)
     account = PaymentAccount(auth_account_id=auth_account_id,
                              payment_method=payment_method,
                              pad_activation_date=date_after_wait_period,
@@ -324,7 +324,7 @@ def factory_create_ejv_account(auth_account_id='1234',
                      stob=stob,
                      project_code=project_code,
                      account_id=account.id,
-                     start_date=datetime.today().date(),
+                     start_date=datetime.now(tz=timezone.utc).date(),
                      created_by='test').save()
     return account
 
@@ -350,7 +350,7 @@ def factory_distribution(name: str, client: str = '111', reps_centre: str = '222
                             project_code=project_code,
                             service_fee_distribution_code_id=service_fee_dist_id,
                             disbursement_distribution_code_id=disbursement_dist_id,
-                            start_date=datetime.today().date(),
+                            start_date=datetime.now(tz=timezone.utc).date(),
                             created_by='test').save()
 
 

--- a/jobs/payment-jobs/tests/jobs/test_activate_pad_account_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_activate_pad_account_task.py
@@ -16,7 +16,7 @@
 
 Test-Suite to ensure that the CreateAccountTask is working as expected.
 """
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from flask import current_app
 from freezegun import freeze_time
@@ -51,7 +51,7 @@ def test_activate_pad_accounts_with_time_check(session):
         'Same day Job runs and shouldnt change anything.'
 
     time_delay = current_app.config['PAD_CONFIRMATION_PERIOD_IN_DAYS']
-    with freeze_time(datetime.today() + timedelta(days=time_delay, minutes=1)):
+    with freeze_time(datetime.now(tz=timezone.utc) + timedelta(days=time_delay, minutes=1)):
         ActivatePadAccountTask.activate_pad_accounts()
         account: PaymentAccount = PaymentAccount.find_by_id(account.id)
         cfs_account = CfsAccount.find_effective_by_payment_method(account.id, PaymentMethod.PAD.value)
@@ -78,7 +78,7 @@ def test_activate_bcol_change_to_pad(session):
     assert account.payment_method == PaymentMethod.DRAWDOWN.value
 
     time_delay = current_app.config['PAD_CONFIRMATION_PERIOD_IN_DAYS']
-    with freeze_time(datetime.today() + timedelta(days=time_delay, minutes=1)):
+    with freeze_time(datetime.now(tz=timezone.utc) + timedelta(days=time_delay, minutes=1)):
         ActivatePadAccountTask.activate_pad_accounts()
         assert cfs_account.status == CfsAccountStatus.ACTIVE.value, \
             'After the confirmation period is over , status should be active'

--- a/jobs/payment-jobs/tests/jobs/test_ejv_partner_distribution_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_ejv_partner_distribution_task.py
@@ -74,7 +74,7 @@ def test_disbursement_for_partners(session, monkeypatch, client_code, batch_type
 
     inv_ref = factory_invoice_reference(invoice_id=invoice.id)
     factory_payment(invoice_number=inv_ref.invoice_number, payment_status_code='COMPLETED')
-    factory_receipt(invoice_id=invoice.id, receipt_date=datetime.today()).save()
+    factory_receipt(invoice_id=invoice.id, receipt_date=datetime.now(tz=timezone.utc)).save()
 
     EjvPartnerDistributionTask.create_ejv_file()
 
@@ -82,7 +82,8 @@ def test_disbursement_for_partners(session, monkeypatch, client_code, batch_type
     invoice = Invoice.find_by_id(invoice.id)
     assert invoice.disbursement_status_code is None
 
-    day_after_time_delay = datetime.today() + timedelta(days=(current_app.config.get('DISBURSEMENT_DELAY_IN_DAYS') + 1))
+    day_after_time_delay = datetime.now(tz=timezone.utc) + \
+        timedelta(days=(current_app.config.get('DISBURSEMENT_DELAY_IN_DAYS') + 1))
     with freeze_time(day_after_time_delay):
         EjvPartnerDistributionTask.create_ejv_file()
         # Lookup invoice and assert disbursement status

--- a/jobs/payment-jobs/tests/jobs/test_ejv_partner_partial_refund_distribution_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_ejv_partner_partial_refund_distribution_task.py
@@ -66,7 +66,7 @@ def test_partial_refund_disbursement(session, monkeypatch):
     refund_partial_link = EjvLink.find_ejv_link_by_link_id(refund_partial.id)
     assert refund_partial_link is None
 
-    day_after_time_delay = datetime.today() + timedelta(days=(
+    day_after_time_delay = datetime.now(tz=timezone.utc) + timedelta(days=(
         current_app.config.get('DISBURSEMENT_DELAY_IN_DAYS') + 1))
 
     with freeze_time(day_after_time_delay):

--- a/jobs/payment-jobs/tests/jobs/test_ejv_partner_partial_refund_distribution_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_ejv_partner_partial_refund_distribution_task.py
@@ -17,7 +17,7 @@
 Test-Suite to ensure that the CgiEjvJob is working as expected.
 """
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from flask import current_app
 from freezegun import freeze_time

--- a/jobs/payment-jobs/tests/jobs/test_unpaid_invoice_notifytask.py
+++ b/jobs/payment-jobs/tests/jobs/test_unpaid_invoice_notifytask.py
@@ -51,21 +51,21 @@ def test_unpaid_one_invoice(session):
     time_delay = current_app.config['NOTIFY_AFTER_DAYS']
 
     # invoke one day before the time delay ;shud be no mail
-    day_after_time_delay = datetime.today() + timedelta(days=(time_delay - 1))
+    day_after_time_delay = datetime.now(tz=timezone.utc) + timedelta(days=(time_delay - 1))
     with freeze_time(day_after_time_delay):
         with patch.object(mailer, 'publish_mailer_events') as mock_mailer:
             UnpaidInvoiceNotifyTask.notify_unpaid_invoices()
             mock_mailer.assert_not_called()
 
     # exact day , mail shud be invoked
-    day_after_time_delay = datetime.today() + timedelta(days=time_delay)
+    day_after_time_delay = datetime.now(tz=timezone.utc) + timedelta(days=time_delay)
     with freeze_time(day_after_time_delay):
         with patch.object(mailer, 'publish_mailer_events') as mock_mailer:
             UnpaidInvoiceNotifyTask.notify_unpaid_invoices()
             mock_mailer.assert_called()
 
     # after the time delay day ;shud not get sent
-    day_after_time_delay = datetime.today() + timedelta(days=time_delay + 1)
+    day_after_time_delay = datetime.now(tz=timezone.utc) + timedelta(days=time_delay + 1)
     with freeze_time(day_after_time_delay):
         with patch.object(mailer, 'publish_mailer_events') as mock_mailer:
             UnpaidInvoiceNotifyTask.notify_unpaid_invoices()
@@ -93,14 +93,14 @@ def test_unpaid_multiple_invoice(session):
 
     # created two invoices ; so two events
     time_delay = current_app.config['NOTIFY_AFTER_DAYS']
-    day_after_time_delay = datetime.today() + timedelta(days=time_delay)
+    day_after_time_delay = datetime.now(tz=timezone.utc) + timedelta(days=time_delay)
     with freeze_time(day_after_time_delay):
         with patch.object(mailer, 'publish_mailer_events') as mock_mailer:
             UnpaidInvoiceNotifyTask.notify_unpaid_invoices()
             assert mock_mailer.call_count == 1
 
     # created one invoice yesterday ; so assert one
-    day_after_time_delay = datetime.today() + timedelta(days=time_delay - 1)
+    day_after_time_delay = datetime.now(tz=timezone.utc) + timedelta(days=time_delay - 1)
     with freeze_time(day_after_time_delay):
         with patch.object(mailer, 'publish_mailer_events') as mock_mailer:
             UnpaidInvoiceNotifyTask.notify_unpaid_invoices()
@@ -120,7 +120,7 @@ def test_unpaid_invoice_pad(session):
 
     # invoke today ;no mail
     time_delay = current_app.config['NOTIFY_AFTER_DAYS']
-    day_after_time_delay = datetime.today() + timedelta(days=time_delay)
+    day_after_time_delay = datetime.now(tz=timezone.utc) + timedelta(days=time_delay)
     with freeze_time(day_after_time_delay):
         with patch.object(mailer, 'publish_mailer_events') as mock_mailer:
             UnpaidInvoiceNotifyTask.notify_unpaid_invoices()
@@ -148,14 +148,14 @@ def test_unpaid_single_invoice_total(session):
 
     # created two invoices ; so two events
     time_delay = current_app.config['NOTIFY_AFTER_DAYS']
-    day_after_time_delay = datetime.today() + timedelta(days=time_delay)
+    day_after_time_delay = datetime.now(tz=timezone.utc) + timedelta(days=time_delay)
     with freeze_time(day_after_time_delay):
         with patch.object(mailer, 'publish_mailer_events') as mock_mailer:
             UnpaidInvoiceNotifyTask.notify_unpaid_invoices()
             assert mock_mailer.call_args.args[2].get('transactionAmount') == total_invoice1 + total_invoice2
 
     # created one invoice yesterday ; so assert one
-    day_after_time_delay = datetime.today() + timedelta(days=time_delay - 1)
+    day_after_time_delay = datetime.now(tz=timezone.utc) + timedelta(days=time_delay - 1)
     with freeze_time(day_after_time_delay):
         with patch.object(mailer, 'publish_mailer_events') as mock_mailer:
             UnpaidInvoiceNotifyTask.notify_unpaid_invoices()
@@ -189,7 +189,7 @@ def test_unpaid_multiple_invoice_total(session):
 
     # created two invoices ; so two events
     time_delay = current_app.config['NOTIFY_AFTER_DAYS']
-    day_after_time_delay = datetime.today() + timedelta(days=time_delay)
+    day_after_time_delay = datetime.now(tz=timezone.utc) + timedelta(days=time_delay)
     total_amount = total_invoice1 + total_invoice2 + total_invoice3
     # total amount is the same for any day invocation
     with freeze_time(day_after_time_delay):
@@ -198,7 +198,7 @@ def test_unpaid_multiple_invoice_total(session):
             assert mock_mailer.call_count == 1
             assert mock_mailer.call_args.args[2].get('transactionAmount') == total_amount
 
-    one_more_day_delay = datetime.today() + timedelta(days=time_delay + 1)
+    one_more_day_delay = datetime.now(tz=timezone.utc) + timedelta(days=time_delay + 1)
     with freeze_time(one_more_day_delay):
         with patch.object(mailer, 'publish_mailer_events') as mock_mailer:
             UnpaidInvoiceNotifyTask.notify_unpaid_invoices()

--- a/pay-api/migrations/versions/6f0fe9f23d8c_distribution_code_changes.py
+++ b/pay-api/migrations/versions/6f0fe9f23d8c_distribution_code_changes.py
@@ -12,7 +12,7 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 
-today = datetime.today().strftime('%Y-%m-%d')
+today = datetime.now(tz=timezone.utc).strftime('%Y-%m-%d')
 
 # revision identifiers, used by Alembic.
 revision = '6f0fe9f23d8c'

--- a/pay-api/src/pay_api/resources/v1/fee.py
+++ b/pay-api/src/pay_api/resources/v1/fee.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Resource for Fee Calculation endpoints."""
-from datetime import datetime
+from datetime import datetime, timezone
 from http import HTTPStatus
 
 from flask import Blueprint, jsonify, request
@@ -35,7 +35,7 @@ bp = Blueprint('FEES', __name__, url_prefix=f'{EndpointEnum.API_V1.value}/fees')
 @_jwt.has_one_of_roles([Role.VIEWER.value, Role.EDITOR.value, Role.STAFF.value])
 def get_fee_by_corp_and_filing_type(corp_type, filing_type_code):
     """Calculate the fee for the filing using the corp type/filing type and return fee."""
-    date = request.args.get('date', datetime.today().strftime(DT_SHORT_FORMAT))
+    date = request.args.get('date', datetime.now(tz=timezone.utc).strftime(DT_SHORT_FORMAT))
     is_priority = convert_to_bool(request.args.get('priority', 'False'))
     is_future_effective = convert_to_bool(request.args.get('futureEffective', 'False'))
     jurisdiction = request.args.get('jurisdiction', DEFAULT_JURISDICTION)

--- a/pay-api/src/pay_api/services/statement.py
+++ b/pay-api/src/pay_api/services/statement.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Service class to control all the operations related to statements."""
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import List
 
 from flask import current_app
@@ -474,7 +474,7 @@ class Statement:  # pylint:disable=too-many-instance-attributes
     @staticmethod
     def generate_interim_statement(auth_account_id: str, new_frequency: str):
         """Generate interim statement."""
-        today = get_local_time(datetime.today())
+        today = get_local_time(datetime.now(tz=timezone.utc))
 
         # This can happen during account creation when the default active settings do not exist yet
         # No interim statement is needed in this case

--- a/pay-api/src/pay_api/services/statement_settings.py
+++ b/pay-api/src/pay_api/services/statement_settings.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Service class to control all the operations related to statements."""
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from flask import current_app
 
@@ -147,7 +147,7 @@ class StatementSettings:  # pylint:disable=too-many-instance-attributes
 
         """
         statements_settings_schema = StatementSettingsModelSchema()
-        today = datetime.today()
+        today = datetime.now(tz=timezone.utc)
         current_statements_settings = StatementSettingsModel.find_active_settings(auth_account_id, today)
         payment_account: PaymentAccountModel = PaymentAccountModel.find_by_auth_account_id(auth_account_id)
         if current_statements_settings is None:
@@ -190,7 +190,7 @@ class StatementSettings:  # pylint:disable=too-many-instance-attributes
     @staticmethod
     def _get_end_of(frequency: StatementFrequency):
         """Return the end of either week or month."""
-        today = datetime.today()
+        today = datetime.now(tz=timezone.utc)
         end_date = current_local_time()
         if frequency == StatementFrequency.WEEKLY.value:
             end_date = get_week_start_and_end_date()[1]

--- a/pay-api/tests/unit/api/test_statement_settings.py
+++ b/pay-api/tests/unit/api/test_statement_settings.py
@@ -18,7 +18,7 @@ Test-Suite to ensure that the /accounts endpoint is working as expected.
 """
 
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import dateutil
 
@@ -51,7 +51,7 @@ def test_get_default_statement_settings_weekly(session, client, jwt, app):
             expected_weekly = (get_week_start_and_end_date()[1] + timedelta(days=1)).date()
             assert actual_weekly == expected_weekly, 'weekly matches'
         if freqeuncy.get('frequency') == StatementFrequency.MONTHLY.value:
-            today = datetime.today()
+            today = datetime.now(tz=timezone.utc)
             actual_monthly = dateutil.parser.parse(freqeuncy.get('startDate')).date()
             expected_monthly = (
                     get_first_and_last_dates_of_month(today.month, today.year)[1] + timedelta(days=1)).date()

--- a/pay-api/tests/unit/factory/test_payment_system_factory.py
+++ b/pay-api/tests/unit/factory/test_payment_system_factory.py
@@ -16,7 +16,7 @@
 
 Test-Suite to ensure that the CorpType Class is working as expected.
 """
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from flask import current_app
@@ -134,7 +134,7 @@ def test_pad_factory_for_system_fails(session, system_user_mock):
     assert excinfo.value.code == Error.ACCOUNT_IN_PAD_CONFIRMATION_PERIOD.name
 
     time_delay = current_app.config['PAD_CONFIRMATION_PERIOD_IN_DAYS']
-    with freeze_time(datetime.today() + timedelta(days=time_delay + 1, minutes=1)):
+    with freeze_time(datetime.now(tz=timezone.utc) + timedelta(days=time_delay + 1, minutes=1)):
         instance = PaymentSystemFactory.create(payment_method='PAD', payment_account=pad_account)
         assert isinstance(instance, PadService)
 

--- a/pay-api/tests/unit/services/test_payment_account.py
+++ b/pay-api/tests/unit/services/test_payment_account.py
@@ -290,7 +290,7 @@ def test_eft_payment_method_settings(session, client, jwt, app, admin_users_mock
     assert payment_account.payment_method == PaymentMethod.EFT.value
 
     statement_settings: StatementSettingsModel = StatementSettingsModel\
-        .find_active_settings(str(payment_account.auth_account_id), datetime.today())
+        .find_active_settings(str(payment_account.auth_account_id), datetime.now(tz=timezone.utc))
 
     assert statement_settings is not None
     assert statement_settings.frequency == StatementFrequency.MONTHLY.value

--- a/pay-api/tests/unit/services/test_statement.py
+++ b/pay-api/tests/unit/services/test_statement.py
@@ -163,7 +163,7 @@ def test_get_weekly_interim_statement(session, admin_users_mock):
 
     # Assert that the default weekly statement settings are created
     statement_settings: StatementSettingsModel = StatementSettingsModel \
-        .find_active_settings(str(account.auth_account_id), datetime.today())
+        .find_active_settings(str(account.auth_account_id), datetime.now(tz=timezone.utc))
 
     assert statement_settings is not None
     assert statement_settings.frequency == StatementFrequency.WEEKLY.value
@@ -218,7 +218,7 @@ def test_get_interim_statement_change_away_from_eft(session, admin_users_mock):
 
     # Assert that the default MONTHLY statement settings are created
     statement_settings: StatementSettingsModel = StatementSettingsModel \
-        .find_active_settings(str(account.auth_account_id), datetime.today())
+        .find_active_settings(str(account.auth_account_id), datetime.now(tz=timezone.utc))
 
     assert statement_settings is not None
     assert statement_settings.frequency == StatementFrequency.MONTHLY.value
@@ -271,7 +271,7 @@ def test_get_monthly_interim_statement(session, admin_users_mock):
 
     # Update current active settings to monthly
     statement_settings: StatementSettingsModel = StatementSettingsModel \
-        .find_active_settings(str(account.auth_account_id), datetime.today())
+        .find_active_settings(str(account.auth_account_id), datetime.now(tz=timezone.utc))
 
     statement_settings.frequency = StatementFrequency.MONTHLY.value
     statement_settings.save()
@@ -330,7 +330,7 @@ def test_interim_statement_settings_eft(db, session, admin_users_mock):
 
     # Confirm initial default settings when account is created
     initial_settings: StatementSettingsModel = StatementSettingsModel \
-        .find_active_settings(str(account.auth_account_id), datetime.today())
+        .find_active_settings(str(account.auth_account_id), datetime.now(tz=timezone.utc))
 
     assert initial_settings is not None
     assert initial_settings.frequency == StatementFrequency.WEEKLY.value
@@ -722,12 +722,12 @@ def test_statement_various_payment_methods_history(db, app):
             get_premium_account_payload(payment_method=PaymentMethod.DRAWDOWN.value))
 
         statement_settings: StatementSettingsModel = StatementSettingsModel \
-            .find_active_settings(str(account.auth_account_id), datetime.today())
+            .find_active_settings(str(account.auth_account_id), datetime.now(tz=timezone.utc))
 
         statement = StatementModel(
             statement_settings_id=statement_settings.id,
             payment_account_id=account.id,
-            created_on=datetime.today(),
+            created_on=datetime.now(tz=timezone.utc),
             from_date=datetime(2024, 1, 1, 12, 0).date(),
             to_date=datetime(2024, 1, 7, 12, 0).date()
         ).flush()

--- a/pay-api/tests/unit/services/test_statement_settings.py
+++ b/pay-api/tests/unit/services/test_statement_settings.py
@@ -16,7 +16,7 @@
 
 Test-Suite to ensure that the Statement Service is working as expected.
 """
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from freezegun import freeze_time
 
@@ -98,7 +98,7 @@ def test_update_statement_daily(session):
 
     # daily to weekly - assert current active one is stil daily ending end of the week
     current_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                             datetime.today())
+                                                                             datetime.now(tz=timezone.utc))
     assert current_statement_settings is not None
     assert current_statement_settings.frequency == StatementFrequency.DAILY.value
     assert current_statement_settings.to_date == end_of_week_date.date()
@@ -106,7 +106,7 @@ def test_update_statement_daily(session):
     # travel to next week and see whats active
     with freeze_time(end_of_week_date + timedelta(days=2)):
         next_week_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                                   datetime.today())
+                                                                                   datetime.now(tz=timezone.utc))
         assert next_week_statement_settings is not None
         assert next_week_statement_settings.frequency == StatementFrequency.WEEKLY.value
         assert next_week_statement_settings.to_date is None
@@ -119,12 +119,13 @@ def test_update_statement_daily(session):
     assert statement_settings.get('to_date') is None
 
     # daily to monthly - assert monthly should start by next month first day
-    end_of_month_date = get_first_and_last_dates_of_month(datetime.today().month, datetime.today().year)[1]
+    end_of_month_date = get_first_and_last_dates_of_month(datetime.now(tz=timezone.utc).month,
+                                                          datetime.now(tz=timezone.utc).year)[1]
     assert statement_settings.get('from_date') == (end_of_month_date + timedelta(days=1)).strftime(DT_SHORT_FORMAT)
 
     # current one is still Ddaily , but ending end of the month
     current_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                             datetime.today())
+                                                                             datetime.now(tz=timezone.utc))
     assert current_statement_settings is not None
     assert current_statement_settings.frequency == StatementFrequency.DAILY.value
     assert current_statement_settings.to_date == end_of_month_date.date()
@@ -132,7 +133,7 @@ def test_update_statement_daily(session):
     # travel to next month and see whats active
     with freeze_time(end_of_month_date + timedelta(days=2)):
         next_week_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                                   datetime.today())
+                                                                                   datetime.now(tz=timezone.utc))
         assert next_week_statement_settings is not None
         assert next_week_statement_settings.frequency == StatementFrequency.MONTHLY.value
         assert next_week_statement_settings.to_date is None
@@ -146,19 +147,20 @@ def test_update_statement_daily(session):
     assert statement_settings.get('to_date') is None
 
     # daily to monthly - assert daily should Tomorrow
-    assert statement_settings.get('from_date') == (datetime.today() + timedelta(days=1)).strftime(DT_SHORT_FORMAT)
+    assert statement_settings.get('from_date') == (datetime.now(tz=timezone.utc).date() + timedelta(days=1)) \
+        .strftime(DT_SHORT_FORMAT)
 
     # current one is still daily , but ending Today
     current_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                             datetime.today())
+                                                                             datetime.now(tz=timezone.utc))
     assert current_statement_settings is not None
     assert current_statement_settings.frequency == StatementFrequency.DAILY.value
-    assert current_statement_settings.to_date == datetime.today().date()
+    assert current_statement_settings.to_date == datetime.now(tz=timezone.utc).date()
 
     # travel to next month and see whats active
     with freeze_time(end_of_month_date + timedelta(days=2)):
         next_week_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                                   datetime.today())
+                                                                                   datetime.now(tz=timezone.utc))
         assert next_week_statement_settings is not None
         assert next_week_statement_settings.frequency == StatementFrequency.DAILY.value
         assert next_week_statement_settings.to_date is None
@@ -186,14 +188,15 @@ def test_update_statement_daily_to_daily(session):
     assert statement_settings.get('to_date') is None
 
     # daily to daily - assert daily should start by tomorow
-    assert statement_settings.get('from_date') == (datetime.today() + timedelta(days=1)).strftime(DT_SHORT_FORMAT)
+    assert statement_settings.get('from_date') == (datetime.now(tz=timezone.utc) + timedelta(days=1)) \
+        .strftime(DT_SHORT_FORMAT)
 
     # daily to daily - assert current active one is stil daily ending today
     current_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                             datetime.today())
+                                                                             datetime.now(tz=timezone.utc))
     assert current_statement_settings is not None
     assert current_statement_settings.frequency == StatementFrequency.DAILY.value
-    assert current_statement_settings.to_date == datetime.today().date()
+    assert current_statement_settings.to_date == datetime.now(tz=timezone.utc).date()
 
 
 def test_update_statement_monthly(session):
@@ -218,12 +221,13 @@ def test_update_statement_monthly(session):
     assert statement_settings.get('to_date') is None
 
     # monthly to weekly - assert weekly should start by next week first day
-    end_of_month_date = get_first_and_last_dates_of_month(datetime.today().month, datetime.today().year)[1]
+    end_of_month_date = get_first_and_last_dates_of_month(datetime.now(tz=timezone.utc).month,
+                                                          datetime.now(tz=timezone.utc).year)[1]
     assert statement_settings.get('from_date') == (end_of_month_date + timedelta(days=1)).strftime(DT_SHORT_FORMAT)
 
     # monthly to weekly - assert current active one is stil monthly ending end of the week
     current_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                             datetime.today())
+                                                                             datetime.now(tz=timezone.utc))
     assert current_statement_settings is not None
     assert current_statement_settings.frequency == StatementFrequency.MONTHLY.value
     assert current_statement_settings.to_date == end_of_month_date.date()
@@ -231,7 +235,7 @@ def test_update_statement_monthly(session):
     # travel to next week and see whats active
     with freeze_time(end_of_month_date + timedelta(days=2)):
         next_week_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                                   datetime.today())
+                                                                                   datetime.now(tz=timezone.utc))
         assert next_week_statement_settings is not None
         assert next_week_statement_settings.frequency == StatementFrequency.WEEKLY.value
         assert next_week_statement_settings.to_date is None
@@ -264,7 +268,7 @@ def test_update_statement_weekly(session):
 
     # daily to weekly - assert current active one is stil daily ending end of the week
     current_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                             datetime.today())
+                                                                             datetime.now(tz=timezone.utc))
     assert current_statement_settings is not None
     assert current_statement_settings.frequency == StatementFrequency.WEEKLY.value
     assert current_statement_settings.to_date == end_of_week_date.date()
@@ -272,7 +276,7 @@ def test_update_statement_weekly(session):
     # travel to next week and see whats active
     with freeze_time(end_of_week_date + timedelta(days=2)):
         next_week_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                                   datetime.today())
+                                                                                   datetime.now(tz=timezone.utc))
         assert next_week_statement_settings is not None
         assert next_week_statement_settings.frequency == StatementFrequency.WEEKLY.value
         assert next_week_statement_settings.to_date is None
@@ -285,12 +289,13 @@ def test_update_statement_weekly(session):
     assert statement_settings.get('to_date') is None
 
     # weekly to monthly - assert monthly should start by next month first day
-    end_of_month_date = get_first_and_last_dates_of_month(datetime.today().month, datetime.today().year)[1]
+    end_of_month_date = get_first_and_last_dates_of_month(datetime.now(tz=timezone.utc).month,
+                                                          datetime.now(tz=timezone.utc).year)[1]
     assert statement_settings.get('from_date') == (end_of_month_date + timedelta(days=1)).strftime(DT_SHORT_FORMAT)
 
     # current one is still weekly , but ending end of the month
     current_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                             datetime.today())
+                                                                             datetime.now(tz=timezone.utc).date())
     assert current_statement_settings is not None
     assert current_statement_settings.frequency == StatementFrequency.WEEKLY.value
     assert current_statement_settings.to_date == end_of_month_date.date()
@@ -298,7 +303,7 @@ def test_update_statement_weekly(session):
     # travel to next month and see whats active
     with freeze_time(end_of_month_date + timedelta(days=2)):
         next_week_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                                   datetime.today())
+                                                                                   datetime.now(tz=timezone.utc).date())
         assert next_week_statement_settings is not None
         assert next_week_statement_settings.frequency == StatementFrequency.MONTHLY.value
         assert next_week_statement_settings.to_date is None
@@ -316,7 +321,7 @@ def test_update_statement_weekly(session):
 
     # current one is still weekly , but ending end of the week
     current_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                             datetime.today())
+                                                                             datetime.now(tz=timezone.utc).date())
     assert current_statement_settings is not None
     assert current_statement_settings.frequency == StatementFrequency.WEEKLY.value
     assert current_statement_settings.to_date == end_of_week_date.date()
@@ -324,7 +329,7 @@ def test_update_statement_weekly(session):
     # travel to next month and see whats active
     with freeze_time(end_of_month_date + timedelta(days=7)):
         next_week_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                                   datetime.today())
+                                                                                   datetime.now(tz=timezone.utc).date())
         assert next_week_statement_settings is not None
         assert next_week_statement_settings.frequency == StatementFrequency.DAILY.value
         assert next_week_statement_settings.to_date is None

--- a/pay-api/tests/unit/services/test_statement_settings.py
+++ b/pay-api/tests/unit/services/test_statement_settings.py
@@ -295,7 +295,7 @@ def test_update_statement_weekly(session):
 
     # current one is still weekly , but ending end of the month
     current_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                             datetime.now(tz=timezone.utc).date())
+                                                                             datetime.now(tz=timezone.utc))
     assert current_statement_settings is not None
     assert current_statement_settings.frequency == StatementFrequency.WEEKLY.value
     assert current_statement_settings.to_date == end_of_month_date.date()
@@ -303,7 +303,7 @@ def test_update_statement_weekly(session):
     # travel to next month and see whats active
     with freeze_time(end_of_month_date + timedelta(days=2)):
         next_week_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                                   datetime.now(tz=timezone.utc).date())
+                                                                                   datetime.now(tz=timezone.utc))
         assert next_week_statement_settings is not None
         assert next_week_statement_settings.frequency == StatementFrequency.MONTHLY.value
         assert next_week_statement_settings.to_date is None
@@ -321,7 +321,7 @@ def test_update_statement_weekly(session):
 
     # current one is still weekly , but ending end of the week
     current_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                             datetime.now(tz=timezone.utc).date())
+                                                                             datetime.now(tz=timezone.utc))
     assert current_statement_settings is not None
     assert current_statement_settings.frequency == StatementFrequency.WEEKLY.value
     assert current_statement_settings.to_date == end_of_week_date.date()
@@ -329,7 +329,7 @@ def test_update_statement_weekly(session):
     # travel to next month and see whats active
     with freeze_time(end_of_month_date + timedelta(days=7)):
         next_week_statement_settings = StatementSettingsModel.find_active_settings(payment_account.auth_account_id,
-                                                                                   datetime.now(tz=timezone.utc).date())
+                                                                                   datetime.now(tz=timezone.utc))
         assert next_week_statement_settings is not None
         assert next_week_statement_settings.frequency == StatementFrequency.DAILY.value
         assert next_week_statement_settings.to_date is None

--- a/pay-api/tests/utilities/base_test.py
+++ b/pay-api/tests/utilities/base_test.py
@@ -927,7 +927,7 @@ def factory_distribution_code(name: str, client: str = '111', reps_centre: str =
                             project_code=project_code,
                             service_fee_distribution_code_id=service_fee_dist_id,
                             disbursement_distribution_code_id=disbursement_dist_id,
-                            start_date=datetime.today().date(),
+                            start_date=datetime.now(tz=timezone.utc).date(),
                             created_by='test')
 
 

--- a/pay-queue/tests/integration/factory.py
+++ b/pay-queue/tests/integration/factory.py
@@ -17,7 +17,7 @@
 Test-Suite to ensure that the service is working as expected.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pay_api.models import (
     CfsAccount, DistributionCode, Invoice, InvoiceReference, Payment, PaymentAccount, PaymentLineItem,
@@ -182,7 +182,7 @@ def factory_create_ejv_account(auth_account_id='1234',
                      stob=stob,
                      project_code=project_code,
                      account_id=account.id,
-                     start_date=datetime.today().date(),
+                     start_date=datetime.now(tz=timezone.utc).date(),
                      created_by='test').save()
     return account
 
@@ -199,7 +199,7 @@ def factory_distribution(name: str, client: str = '111', reps_centre: str = '222
                             project_code=project_code,
                             service_fee_distribution_code_id=service_fee_dist_id,
                             disbursement_distribution_code_id=disbursement_dist_id,
-                            start_date=datetime.today().date(),
+                            start_date=datetime.now(tz=timezone.utc).date(),
                             created_by='test').save()
 
 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
