### PR TITLE
21528 - EFT Reverse Payment Fix

### DIFF
--- a/pay-api/src/pay_api/services/eft_short_names.py
+++ b/pay-api/src/pay_api/services/eft_short_names.py
@@ -296,6 +296,8 @@ class EFTShortnames:  # pylint: disable=too-many-instance-attributes
             EFTCreditInvoiceLinkModel(
                 eft_credit_id=eft_credit.id,
                 status_code=EFTCreditInvoiceStatus.PENDING_REFUND.value,
+                amount=current_link.amount,
+                receipt_number=current_link.receipt_number,
                 invoice_id=invoice.id,
                 link_group_id=link_group_id).flush()
 

--- a/pay-api/src/pay_api/version.py
+++ b/pay-api/src/pay_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.21.4'  # pylint: disable=invalid-name
+__version__ = '1.21.5'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/21528

*Description of changes:*
- update EFT payment reversal action to populate missing amount and receipt information from COMPLETED link

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
