### PR TITLE
20415 - Fix / Update to linking modal backend calls

### DIFF
--- a/pay-api/src/pay_api/resources/v1/eft_short_names.py
+++ b/pay-api/src/pay_api/resources/v1/eft_short_names.py
@@ -52,10 +52,13 @@ def get_eft_shortnames():
     account_id = request.args.get('accountId', None)
     account_name = request.args.get('accountName', None)
     account_branch = request.args.get('accountBranch', None)
+    account_id_list = request.args.get('accountIdList', None)
+    account_id_list = account_id_list.split(',') if account_id_list else None
 
     response, status = EFTShortnameService.search(EFTShortnamesSearch(
         id=short_name_id,
         account_id=account_id,
+        account_id_list=account_id_list,
         account_name=account_name,
         account_branch=account_branch,
         amount_owing=string_to_decimal(amount_owing),

--- a/pay-api/src/pay_api/services/eft_short_names.py
+++ b/pay-api/src/pay_api/services/eft_short_names.py
@@ -55,6 +55,7 @@ class EFTShortnamesSearch:  # pylint: disable=too-many-instance-attributes
 
     id: Optional[int] = None
     account_id: Optional[str] = None
+    account_id_list: Optional[List[str]] = None
     allow_partial_account_id: Optional[bool] = True
     account_name: Optional[str] = None
     account_branch: Optional[str] = None
@@ -694,6 +695,9 @@ class EFTShortnames:  # pylint: disable=too-many-instance-attributes
                 links_subquery.c.total_owing,
                 links_subquery.c.latest_statement_id
             )
+
+        if search_criteria.account_id_list:
+            query = query.filter(links_subquery.c.auth_account_id.in_(search_criteria.account_id_list))
 
         query = cls.get_link_state_filters(search_criteria, query, links_subquery)
         # Short name filters

--- a/pay-api/src/pay_api/version.py
+++ b/pay-api/src/pay_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '1.21.6'  # pylint: disable=invalid-name
+__version__ = '1.21.7'  # pylint: disable=invalid-name

--- a/pay-api/tests/conftest.py
+++ b/pay-api/tests/conftest.py
@@ -296,12 +296,3 @@ def admin_users_mock(monkeypatch):
         }
     monkeypatch.setattr('pay_api.services.payment_account.PaymentAccount._get_account_admin_users',
                         _get_account_admin_users)
-
-
-@pytest.fixture()
-def non_active_accounts_auth_api_mock(monkeypatch):
-    """Mock auth rest call to get non-active orgs."""
-    def _get_non_active_orgs():
-        return ['911']
-    monkeypatch.setattr('pay_api.services.payment_account.PaymentAccount._get_non_active_org_ids',
-                        _get_non_active_orgs)

--- a/pay-api/tests/unit/api/test_eft_short_names.py
+++ b/pay-api/tests/unit/api/test_eft_short_names.py
@@ -863,6 +863,23 @@ def test_search_eft_short_names(session, client, jwt, app):
                       data_dict['single-linked']['accounts'][0],
                       data_dict['single-linked']['statement_summary'][0])
 
+    # Assert search account id list
+    rv = client.get('/api/v1/eft-shortnames?state=LINKED&accountIdList=1111,999', headers=headers)
+    assert rv.status_code == 200
+
+    result_dict = rv.json
+    assert result_dict is not None
+    assert result_dict['page'] == 1
+    assert result_dict['stateTotal'] == 2
+    assert result_dict['total'] == 1
+    assert result_dict['limit'] == 10
+    assert result_dict['items'] is not None
+    assert len(result_dict['items']) == 1
+    assert_short_name(result_dict['items'][0],
+                      data_dict['single-linked']['short_name'],
+                      data_dict['single-linked']['accounts'][0],
+                      data_dict['single-linked']['statement_summary'][0])
+
 
 def test_post_shortname_refund_success(client, mocker, jwt, app):
     """Test successful creation of a shortname refund."""


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/20415

*Description of changes:*
- update search eft accounts to check against CFS accounts, we should no longer need to call auth so this was removed
- added accountIdList query parameter back to short name search to allow for searches that are partial matches to properly surface status and amount owing information
- update tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
