### PR TITLE
20415 - fix EFT linking search counts / pagination

### DIFF
--- a/pay-api/src/pay_api/services/eft_short_names.py
+++ b/pay-api/src/pay_api/services/eft_short_names.py
@@ -590,7 +590,10 @@ class EFTShortnames:  # pylint: disable=too-many-instance-attributes
             StatementInvoicesModel.statement_id == StatementModel.id
         ).join(
             InvoiceModel,
-            InvoiceModel.id == StatementInvoicesModel.invoice_id
+            and_(
+                InvoiceModel.id == StatementInvoicesModel.invoice_id,
+                InvoiceModel.payment_method_code == PaymentMethod.EFT.value
+            )
         ).group_by(StatementModel.payment_account_id)
 
     @classmethod
@@ -644,10 +647,12 @@ class EFTShortnames:  # pylint: disable=too-many-instance-attributes
                                     CfsAccountModel.status.label('cfs_account_status'),
                                     PaymentAccountModel.name,
                                     PaymentAccountModel.branch_name) \
+            .distinct(EFTShortnameLinksModel.auth_account_id) \
             .outerjoin(PaymentAccountModel,
                        PaymentAccountModel.auth_account_id == EFTShortnameLinksModel.auth_account_id) \
             .outerjoin(CfsAccountModel,
-                       CfsAccountModel.account_id == PaymentAccountModel.id)
+                       CfsAccountModel.account_id == PaymentAccountModel.id) \
+            .order_by(EFTShortnameLinksModel.auth_account_id, EFTShortnameLinksModel.updated_on.desc())
 
         query = db.session.query(EFTShortnameModel.id,
                                  EFTShortnameModel.short_name,

--- a/pay-api/tests/unit/api/test_statement.py
+++ b/pay-api/tests/unit/api/test_statement.py
@@ -253,7 +253,9 @@ def test_statement_summary(session, client, jwt, app):
     oldest_due_date = datetime.now(tz=timezone.utc) + relativedelta(months=1)
     for _ in range(5):
         rv = client.post('/api/v1/payment-requests',
-                         data=json.dumps(get_payment_request(business_identifier='CP0002000')),
+                         data=json.dumps(get_payment_request_with_payment_method(business_identifier='CP0002000',
+                                                                                 payment_method=PaymentMethod.EFT.value)
+                                         ),
                          headers=headers)
         invoice_ids.append(rv.json.get('id'))
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/20415
https://github.com/bcgov/entity/issues/21981

*Description of changes:*
- Payment Method filter on statement owing summary (this query specifically for short name usage, so it should be filtering by EFT code)
- Fix links subquery so it pulls the latest record for an account, and considers the most recent link (could have been unlinked from a different account)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
