### PR TITLE
22391, 21560 - Statement Owing Caution, Reminder notifications

### DIFF
--- a/jobs/payment-jobs/poetry.lock
+++ b/jobs/payment-jobs/poetry.lock
@@ -2025,9 +2025,9 @@ werkzeug = "3.0.1"
 
 [package.source]
 type = "git"
-url = "https://github.com/seeker25/sbc-pay.git"
-reference = "22655"
-resolved_reference = "55828250fd4ed135ec7f4d2e3034bb91f5540454"
+url = "https://github.com/ochiu/sbc-pay.git"
+reference = "22391-21560"
+resolved_reference = "717024fc7d382ee3c2226d16b88a069b545cca07"
 subdirectory = "pay-api"
 
 [[package]]
@@ -3169,4 +3169,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "d116949d2f4a0b53bba4c39f7ae7fe363e0499ace93e77cba794e781cc700489"
+content-hash = "eac7f5e0117d982061eca6ef4c567ac5f6ebcefc8289ee1a9e6f35a7350cad77"

--- a/jobs/payment-jobs/pyproject.toml
+++ b/jobs/payment-jobs/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-pay-api = {git = "https://github.com/seeker25/sbc-pay.git", branch = "22655", subdirectory = "pay-api"}
+pay-api = {git = "https://github.com/ochiu/sbc-pay.git", branch = "22391-21560", subdirectory = "pay-api"}
 gunicorn = "^21.2.0"
 flask = "^3.0.2"
 flask-sqlalchemy = "^3.1.1"

--- a/jobs/payment-jobs/tasks/statement_due_task.py
+++ b/jobs/payment-jobs/tasks/statement_due_task.py
@@ -19,6 +19,7 @@ import pytz
 from flask import current_app
 from pay_api.models import db
 from pay_api.models.cfs_account import CfsAccount as CfsAccountModel
+from pay_api.models.eft_short_name_links import EFTShortnameLinks as EFTShortnameLinksModel
 from pay_api.models.invoice import Invoice as InvoiceModel
 from pay_api.models.invoice_reference import InvoiceReference as InvoiceReferenceModel
 from pay_api.models.non_sufficient_funds import NonSufficientFunds as NonSufficientFundsModel
@@ -148,13 +149,15 @@ class StatementDueTask:   # pylint: disable=too-few-public-methods
                                                 f' notification for auth_account_id='
                                                 f'{payment_account.auth_account_id}, payment_account_id='
                                                 f'{payment_account.id}')
+                        links_count = EFTShortnameLinksModel.get_short_name_links_count(payment_account.auth_account_id)
                         publish_payment_notification(
                             StatementNotificationInfo(auth_account_id=payment_account.auth_account_id,
                                                       statement=statement,
                                                       action=action,
                                                       due_date=due_date,
                                                       emails=emails,
-                                                      total_amount_owing=total_due))
+                                                      total_amount_owing=total_due,
+                                                      short_name_links_count=links_count))
             except Exception as e:  # NOQA # pylint: disable=broad-except
                 capture_message(
                     f'Error on unpaid statement notification auth_account_id={payment_account.auth_account_id}, '

--- a/jobs/payment-jobs/tests/jobs/test_statement_due_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_statement_due_task.py
@@ -133,7 +133,8 @@ def test_send_unpaid_statement_notification(setup, session, test_name, action_on
                                                                              action=action,
                                                                              due_date=due_date,
                                                                              emails=statement_recipient.email,
-                                                                             total_amount_owing=total_amount_owing))
+                                                                             total_amount_owing=total_amount_owing,
+                                                                             short_name_links_count=0))
 
 
 def test_unpaid_statement_notification_not_sent(setup, session):

--- a/jobs/payment-jobs/utils/mailer.py
+++ b/jobs/payment-jobs/utils/mailer.py
@@ -114,6 +114,8 @@ def publish_payment_notification(info: StatementNotificationInfo) -> bool:
         'accountId': info.auth_account_id,
         'dueDate': f'{info.due_date}',
         'statementFrequency': info.statement.frequency,
+        'statementMonth': info.statement.from_date.strftime('%B'),
+        'statementNumber': info.statement.id,
         'totalAmountOwing': info.total_amount_owing,
         'shortNameLinksCount': info.short_name_links_count
     }

--- a/jobs/payment-jobs/utils/mailer.py
+++ b/jobs/payment-jobs/utils/mailer.py
@@ -114,7 +114,8 @@ def publish_payment_notification(info: StatementNotificationInfo) -> bool:
         'accountId': info.auth_account_id,
         'dueDate': f'{info.due_date}',
         'statementFrequency': info.statement.frequency,
-        'totalAmountOwing': info.total_amount_owing
+        'totalAmountOwing': info.total_amount_owing,
+        'shortNameLinksCount': info.short_name_links_count
     }
     try:
         gcp_queue_publisher.publish_to_queue(

--- a/jobs/payment-jobs/utils/mailer.py
+++ b/jobs/payment-jobs/utils/mailer.py
@@ -37,6 +37,7 @@ class StatementNotificationInfo:
     due_date: datetime
     emails: str
     total_amount_owing: float
+    short_name_links_count: int
 
 
 def publish_mailer_events(message_type: str, pay_account: PaymentAccountModel, additional_params=None):

--- a/pay-api/src/pay_api/models/eft_short_name_links.py
+++ b/pay-api/src/pay_api/models/eft_short_name_links.py
@@ -89,6 +89,23 @@ class EFTShortnameLinks(Versioned, BaseModel):  # pylint: disable=too-many-insta
                 .filter(cls.status_code.in_(statuses))
                 ).one_or_none()
 
+    @classmethod
+    def get_short_name_links_count(cls, auth_account_id):
+        """Find short name account link by status."""
+        statuses = [EFTShortnameStatus.LINKED.value,
+                    EFTShortnameStatus.PENDING.value]
+        active_link = (cls.query
+                       .filter_by(auth_account_id=auth_account_id)
+                       .filter(cls.status_code.in_(statuses))
+                       ).one_or_none()
+
+        if active_link is None:
+            return 0
+
+        return (cls.query
+                .filter_by(eft_short_name_id=active_link.eft_short_name_id)
+                .filter(cls.status_code.in_(statuses))).count()
+
 
 @define
 class EFTShortnameLinkSchema:  # pylint: disable=too-few-public-methods

--- a/pay-api/src/pay_api/services/statement.py
+++ b/pay-api/src/pay_api/services/statement.py
@@ -22,6 +22,7 @@ from sqlalchemy.dialects.postgresql import ARRAY, INTEGER
 
 from pay_api.models import EFTCredit as EFTCreditModel
 from pay_api.models import EFTCreditInvoiceLink as EFTCreditInvoiceLinkModel
+from pay_api.models import EFTShortnameLinks as EFTShortnameLinksModel
 from pay_api.models import EFTTransaction as EFTTransactionModel
 from pay_api.models import Invoice as InvoiceModel
 from pay_api.models import Payment as PaymentModel
@@ -385,11 +386,13 @@ class Statement:  # pylint:disable=too-many-instance-attributes,too-many-public-
 
         # Unpaid invoice amount total that are not part of a statement yet
         invoices_unpaid_amount = Statement.get_invoices_owing_amount(auth_account_id)
+        short_name_links_count = EFTShortnameLinksModel.get_short_name_links_count(auth_account_id)
 
         return {
             'total_invoice_due': float(invoices_unpaid_amount) if invoices_unpaid_amount else 0,
             'total_due': total_due,
-            'oldest_due_date': oldest_due_date
+            'oldest_due_date': oldest_due_date,
+            'short_name_links_count': short_name_links_count
         }
 
     @staticmethod

--- a/pay-api/tests/unit/api/test_statement.py
+++ b/pay-api/tests/unit/api/test_statement.py
@@ -278,6 +278,7 @@ def test_statement_summary(session, client, jwt, app):
     assert rv.status_code == 200
     assert rv.json.get('totalDue') == float(total_due)
     assert rv.json.get('oldestDueDate') == (oldest_due_date.date() + relativedelta(hours=8)).isoformat()
+    assert rv.json.get('shortNameLinksCount') == 0
 
 
 def test_statement_summary_with_eft_invoices_no_statement(session, client, jwt, app):
@@ -312,3 +313,4 @@ def test_statement_summary_with_eft_invoices_no_statement(session, client, jwt, 
     assert rv.json.get('totalDue') == 0
     assert rv.json.get('oldestDueDate') is None
     assert rv.json.get('totalInvoiceDue') == float(unpaid_amount)
+    assert rv.json.get('shortNameLinksCount') == 0


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/21560
https://github.com/bcgov/entity/issues/22391

*Description of changes:*
- statement_due_task - add link count for statement templates to determine template content
- eft statement summary - add link count to show caution text for multi linked accounts with an amount owing


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
