### PR TITLE
21539 - Short name history eft refund fix

### DIFF
--- a/pay-api/src/pay_api/models/eft_short_names_historical.py
+++ b/pay-api/src/pay_api/models/eft_short_names_historical.py
@@ -94,6 +94,7 @@ class EFTShortnameHistorySchema:  # pylint: disable=too-few-public-methods
     account_branch: str
     amount: Decimal
     invoice_id: int
+    eft_refund_id: int
     statement_number: int
     short_name_id: int
     short_name_balance: Decimal
@@ -116,6 +117,7 @@ class EFTShortnameHistorySchema:  # pylint: disable=too-few-public-methods
                    account_name=getattr(row, 'account_name', None),
                    account_branch=getattr(row, 'account_branch', None),
                    invoice_id=getattr(row, 'invoice_id', None),
+                   eft_refund_id=getattr(row, 'eft_refund_id', None),
                    statement_number=getattr(row, 'statement_number', None),
                    transaction_date=getattr(row, 'transaction_date', None),
                    transaction_type=getattr(row, 'transaction_type', None),

--- a/pay-api/src/pay_api/services/eft_short_name_historical.py
+++ b/pay-api/src/pay_api/services/eft_short_name_historical.py
@@ -208,6 +208,7 @@ class EFTShortnameHistorical:
                                   history_model.amount,
                                   history_model.credit_balance,
                                   history_model.invoice_id,
+                                  history_model.eft_refund_id,
                                   history_model.statement_number,
                                   history_model.transaction_date,
                                   history_model.transaction_type,

--- a/pay-api/tests/unit/api/test_eft_short_name_history.py
+++ b/pay-api/tests/unit/api/test_eft_short_name_history.py
@@ -53,6 +53,13 @@ def setup_test_data(exclude_history: bool = False):
                                                               related_group_link_id=2,
                                                               statement_number=1234)).save()
 
+        EFTHistoryService.create_shortname_refund(EFTHistory(short_name_id=short_name.id,
+                                                             amount=351.50,
+                                                             credit_balance=351.50,
+                                                             payment_account_id=payment_account.id,
+                                                             related_group_link_id=2,
+                                                             statement_number=1234)).save()
+
     return payment_account, short_name
 
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/21539

*Description of changes:*
- add eft_refund_id to short name history response

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
