### PR TITLE
21516 - EFT Over payment notification task

### DIFF
--- a/jobs/payment-jobs/invoke_jobs.py
+++ b/jobs/payment-jobs/invoke_jobs.py
@@ -149,7 +149,6 @@ def run(job_name, argument=None):
             application.logger.info('<<<< Completed EFT tasks >>>>')
         case 'EFT_OVERPAYMENT':
             date_override = argument[0] if len(argument) >= 1 else None
-            auth_account_override = argument[1] if len(argument) >= 2 else None
             EFTOverpaymentNotificationTask.process_overpayment_notification(date_override=date_override)
             application.logger.info(
                 '<<<< Completed Sending notification for EFT Over Payment >>>>')

--- a/jobs/payment-jobs/run_eft_overpayment_notification_task.sh
+++ b/jobs/payment-jobs/run_eft_overpayment_notification_task.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+echo 'run invoke_jobs.py EFT_OVERPAYMENT'
+python3 invoke_jobs.py EFT_OVERPAYMENT

--- a/jobs/payment-jobs/services/email_service.py
+++ b/jobs/payment-jobs/services/email_service.py
@@ -1,0 +1,68 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This manages all of the email notification service."""
+import os
+from typing import Dict
+from decimal import Decimal
+
+from attr import define
+from flask import current_app
+from jinja2 import Environment, FileSystemLoader
+from pay_api.services.auth import get_service_account_token
+from pay_api.services.oauth_service import OAuthService
+from pay_api.utils.enums import AuthHeaderType, ContentType
+
+
+def send_email(recipients: str, subject: str, body: str):
+    """Send the email notification."""
+    # Note if we send HTML in the body, we aren't sending through GCNotify, ideally we'd like to send through GCNotify.
+    token = get_service_account_token()
+    current_app.logger.info(f'>send_email to recipients: {recipients}')
+    notify_url = current_app.config.get('NOTIFY_API_ENDPOINT') + 'notify/'
+    notify_body = {
+        'recipients': recipients,
+        'content': {
+            'subject': subject,
+            'body': body
+        }
+    }
+
+    try:
+        notify_response = OAuthService.post(notify_url, token=token,
+                                            auth_header_type=AuthHeaderType.BEARER,
+                                            content_type=ContentType.JSON, data=notify_body)
+        current_app.logger.info('<send_email notify_response')
+        if notify_response:
+            current_app.logger.info(f'Successfully sent email to {recipients}')
+    except Exception as e:  # NOQA pylint:disable=broad-except
+        current_app.logger.error(f'Error sending email to {recipients}: {e}')
+
+
+def _get_template(template_file_name: str):
+    """Retrieve template."""
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root_dir = os.path.dirname(current_dir)
+    templates_dir = os.path.join(project_root_dir, 'templates')
+    env = Environment(loader=FileSystemLoader(templates_dir), autoescape=True)
+    return env.get_template(template_file_name)
+
+
+def _render_eft_overpayment_template(params: Dict) -> str:
+    """Render eft overpayment template."""
+    template = _get_template('eft_overpayment.html')
+    short_name_detail_url = f"{current_app.config.get('AUTH_WEB_URL')}/pay/short-name-details/{params['shortNameId']}"
+    params['shortNameDetailUrl'] = short_name_detail_url
+
+    return template.render(params)

--- a/jobs/payment-jobs/tasks/eft_overpayment_notification_task.py
+++ b/jobs/payment-jobs/tasks/eft_overpayment_notification_task.py
@@ -1,0 +1,128 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Task to notify staff user for short name over payments."""
+from datetime import datetime, timedelta, timezone
+from typing import List
+
+from flask import current_app
+from pay_api.models import db
+from pay_api.models.eft_credit import EFTCredit as EFTCreditModel
+from pay_api.models.eft_short_name_links import EFTShortnameLinks as EFTShortnameLinkModel
+from pay_api.models.eft_short_names import EFTShortnames as EFTShortnameModel
+from pay_api.services.auth import get_emails_with_keycloak_role
+from pay_api.utils.enums import EFTShortnameStatus, Role
+from sentry_sdk import capture_message
+from sqlalchemy import and_, func
+
+from services.email_service import _render_eft_overpayment_template, send_email
+
+
+class EFTOverpaymentNotificationTask:  # pylint: disable=too-few-public-methods
+    """Task to notify staff qualified receivers.
+
+    Notify staff qualified receiver there is a pending unsettled amount on a short name due to overpayment or an account
+    has not been linked for thirty days.
+    """
+
+    date_override = None
+    short_names: dict = {}
+
+    @classmethod
+    def _get_base_query(cls):
+        """Create base query for returning short names with any remaining credits by filter date."""
+        query = (db.session.query(EFTShortnameModel)
+                 .distinct(EFTShortnameModel.id)
+                 .join(EFTCreditModel, EFTCreditModel.short_name_id == EFTShortnameModel.id)
+                 .filter(EFTCreditModel.remaining_amount > 0)
+                 .order_by(EFTShortnameModel.id, EFTCreditModel.created_on.asc())
+                 )
+        return query
+
+    @classmethod
+    def _get_today_overpaid_linked_short_names(cls):
+        """Get linked short names that have received a payment today and overpaid."""
+        filter_date = cls.date_override if cls.date_override is not None else datetime.now(tz=timezone.utc).date()
+        query = (cls._get_base_query()
+                 .join(EFTShortnameLinkModel,
+                       and_(EFTShortnameLinkModel.eft_short_name_id == EFTShortnameModel.id,
+                            EFTShortnameLinkModel.status_code.in_([EFTShortnameStatus.LINKED.value,
+                                                                   EFTShortnameStatus.PENDING.value]))
+                       )
+                 .filter(func.date(EFTCreditModel.created_on) == filter_date))
+        return query.all()
+
+    @classmethod
+    def _get_unlinked_short_names_for_duration(cls, days_duration: int = 30):
+        """Get short names that have been unlinked for a duration in days."""
+        execution_date = cls.date_override if cls.date_override is not None else datetime.now(tz=timezone.utc).date()
+        duration_date = execution_date - timedelta(days=days_duration)
+        query = (cls._get_base_query()
+                 .outerjoin(EFTShortnameLinkModel,
+                            and_(EFTShortnameLinkModel.eft_short_name_id == EFTShortnameModel.id,
+                                 EFTShortnameLinkModel.status_code.in_([EFTShortnameStatus.LINKED.value,
+                                                                        EFTShortnameStatus.PENDING.value]))
+                            )
+                 .filter(EFTShortnameLinkModel.id.is_(None))
+                 .filter(func.date(EFTShortnameModel.created_on) == duration_date)
+                 )
+
+        return query.all()
+
+    @classmethod
+    def _update_short_name_dict(cls, short_name_models: List[EFTShortnameModel]):
+        for short_name in short_name_models:
+            cls.short_names[short_name.id] = short_name.short_name
+
+    @classmethod
+    def process_overpayment_notification(cls, date_override=None):
+        """Notify for over payments and short name unlinked for thirty days."""
+        try:
+            cls.short_names = {}
+            if cls.date_override:
+                cls.date_override = datetime.strptime(date_override, '%Y-%m-%d') if date_override else None
+                current_app.logger.info(f'Using date override : {date_override}')
+
+            # Get short names that have EFT credit rows created based on current / override date indicating payment
+            # was received and credits remaining indicate overpayment
+            linked_short_names = cls._get_today_overpaid_linked_short_names()
+
+            # Get short names that have credits remaining and have been unlinked for thirty days
+            unlinked_short_names = cls._get_unlinked_short_names_for_duration()
+
+            cls._update_short_name_dict(linked_short_names)
+            cls._update_short_name_dict(unlinked_short_names)
+            current_app.logger.info(f'Sending over payment notifications for {len(cls.short_names)} short names.')
+            cls._send_notifications()
+        except Exception as e:  # NOQA # pylint: disable=broad-except
+            capture_message(
+                'Error on processing over payment notifications'
+                f'ERROR : {str(e)}', level='error')
+            current_app.logger.error(
+                'Error on processing over payment notifications', exc_info=True)
+
+    @classmethod
+    def _send_notifications(cls):
+        """Send over payment notification."""
+        if cls.short_names:
+            qualified_receiver_recipients = get_emails_with_keycloak_role(Role.EFT_REFUND.value)
+            for short_name_id, name in cls.short_names.items():
+                credit_balance = EFTCreditModel.get_eft_credit_balance(short_name_id)
+                template_params = {
+                    'shortNameId': short_name_id,
+                    'shortName': name,
+                    'unsettledAmount': f'{credit_balance:,.2f}'
+                }
+                send_email(recipients=qualified_receiver_recipients,
+                           subject=f'Pending Unsettled Amount for Short Name {name}',
+                           body=_render_eft_overpayment_template(template_params))

--- a/jobs/payment-jobs/tasks/eft_overpayment_notification_task.py
+++ b/jobs/payment-jobs/tasks/eft_overpayment_notification_task.py
@@ -89,7 +89,7 @@ class EFTOverpaymentNotificationTask:  # pylint: disable=too-few-public-methods
         """Notify for over payments and short name unlinked for thirty days."""
         try:
             cls.short_names = {}
-            if cls.date_override:
+            if date_override:
                 cls.date_override = datetime.strptime(date_override, '%Y-%m-%d') if date_override else None
                 current_app.logger.info(f'Using date override : {date_override}')
 

--- a/jobs/payment-jobs/tasks/eft_statement_due_task.py
+++ b/jobs/payment-jobs/tasks/eft_statement_due_task.py
@@ -43,7 +43,7 @@ from utils.mailer import StatementNotificationInfo, publish_payment_notification
 # IMPORTANT: Due to the nature of dates, run this job at least 08:00 UTC or greater.
 # Otherwise it could be triggered the day before due to timeshift for PDT/PST.
 # It also needs to run after the statements job.
-class StatementDueTask:   # pylint: disable=too-few-public-methods
+class EFTStatementDueTask:   # pylint: disable=too-few-public-methods
     """Task to notify admin for unpaid statements.
 
     This is currently for EFT payment method invoices only. This may be expanded to

--- a/jobs/payment-jobs/templates/eft_overpayment.html
+++ b/jobs/payment-jobs/templates/eft_overpayment.html
@@ -1,0 +1,7 @@
+# Pending Unsettled Amount for Short Name {{ shortName }}
+
+There is an unsettled amount of ${{ unsettledAmount }} on short name: {{ shortName }}.
+
+Please review the information using the following link:
+
+[Log in to view detail]({{ shortNameDetailUrl }})

--- a/jobs/payment-jobs/tests/jobs/conftest.py
+++ b/jobs/payment-jobs/tests/jobs/conftest.py
@@ -16,6 +16,7 @@
 
 import os
 import time
+from unittest.mock import Mock
 
 import pytest
 from flask_migrate import Migrate, upgrade
@@ -180,3 +181,22 @@ def admin_users_mock(monkeypatch):
         }
     monkeypatch.setattr('pay_api.services.auth.get_account_admin_users',
                         get_account_admin_users)
+
+
+@pytest.fixture()
+def emails_with_keycloak_role_mock(monkeypatch):
+    """Mock auth rest call to get org admins."""
+    def get_emails_with_keycloak_role(role):
+        return 'test@email.com'
+
+    monkeypatch.setattr('tasks.eft_overpayment_notification_task.get_emails_with_keycloak_role',
+                        get_emails_with_keycloak_role)
+
+
+@pytest.fixture()
+def send_email_mock(monkeypatch):
+    """Mock send_email."""
+    send_email = Mock(return_value=True)
+    monkeypatch.setattr('tasks.eft_overpayment_notification_task.send_email',
+                        send_email)
+    return send_email

--- a/jobs/payment-jobs/tests/jobs/test_eft_overpayment_notification_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_eft_overpayment_notification_task.py
@@ -1,0 +1,159 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to assure the EFTOverpaymentNotificationTask.
+
+Test-Suite to ensure that the EFTOverpaymentNotificationTask is working as expected.
+"""
+from datetime import datetime, timedelta
+from unittest.mock import ANY, call, patch
+
+import pytest
+from freezegun import freeze_time
+from pay_api.utils.enums import EFTShortnameStatus
+
+from tasks.eft_overpayment_notification_task import EFTOverpaymentNotificationTask
+
+from .factory import (
+    factory_create_eft_credit, factory_create_eft_file, factory_create_eft_shortname, factory_create_eft_transaction,
+    factory_eft_shortname_link)
+
+
+def create_unlinked_short_names_data(created_on: datetime):
+    """Create seed data for unlinked short names."""
+    eft_file = factory_create_eft_file()
+    eft_transaction = factory_create_eft_transaction(file_id=eft_file.id)
+    unlinked_with_credit = factory_create_eft_shortname('UNLINKED_WITH_CREDIT')
+    unlinked_with_credit.created_on = created_on
+    unlinked_with_credit.save()
+    factory_create_eft_credit(
+        short_name_id=unlinked_with_credit.id,
+        eft_transaction_id=eft_transaction.id,
+        eft_file_id=eft_file.id,
+        amount=100,
+        remaining_amount=100
+    )
+
+    inactive_link_with_credit = factory_create_eft_shortname('INACTIVE_LINK_WITH_CREDIT')
+    inactive_link_with_credit.created_on = created_on
+    inactive_link_with_credit.save()
+    factory_create_eft_credit(
+        short_name_id=inactive_link_with_credit.id,
+        eft_transaction_id=eft_transaction.id,
+        eft_file_id=eft_file.id,
+        amount=10,
+        remaining_amount=10
+    )
+    factory_eft_shortname_link(short_name_id=inactive_link_with_credit.id,
+                               status_code=EFTShortnameStatus.INACTIVE.value)
+
+    # Create unlinked short name that is not 30 days old yet
+    unlinked_not_included = factory_create_eft_shortname('UNLINKED_NOT_INCLUDED')
+    unlinked_not_included.created_on = created_on + timedelta(days=1)
+    unlinked_not_included.save()
+    factory_create_eft_credit(
+        short_name_id=unlinked_not_included.id,
+        eft_transaction_id=eft_transaction.id,
+        eft_file_id=eft_file.id,
+        amount=100,
+        remaining_amount=100
+    )
+
+    return unlinked_with_credit, inactive_link_with_credit, unlinked_not_included
+
+
+def create_linked_short_names_data(created_on: datetime):
+    """Create seed data for linked short names."""
+    eft_file = factory_create_eft_file()
+    eft_transaction = factory_create_eft_transaction(file_id=eft_file.id)
+    linked_with_credit = factory_create_eft_shortname('LINKED_WITH_CREDIT')
+    credit_1 = factory_create_eft_credit(
+        short_name_id=linked_with_credit.id,
+        eft_transaction_id=eft_transaction.id,
+        eft_file_id=eft_file.id,
+        amount=100,
+        remaining_amount=100
+    )
+    credit_1.created_on = created_on
+    credit_1.save()
+    factory_eft_shortname_link(short_name_id=linked_with_credit.id)
+
+    linked_with_no_credit = factory_create_eft_shortname('LINKED_WITH_NO_CREDIT')
+    credit_2 = factory_create_eft_credit(
+        short_name_id=linked_with_no_credit.id,
+        eft_transaction_id=eft_transaction.id,
+        eft_file_id=eft_file.id,
+        amount=100,
+        remaining_amount=0
+    )
+    credit_2.created_on = created_on
+    credit_2.save()
+    factory_eft_shortname_link(short_name_id=linked_with_no_credit.id)
+    return linked_with_credit, linked_with_no_credit
+
+
+def test_over_payment_notification_not_sent(session):
+    """Assert notification is not being sent."""
+    with patch('tasks.eft_overpayment_notification_task.send_email') as mock_mailer:
+        EFTOverpaymentNotificationTask.process_overpayment_notification()
+        mock_mailer.assert_not_called()
+
+
+@pytest.mark.parametrize('test_name, created_on_date, execution_date, assert_calls_override', [
+    ('has-notifications', datetime(2024, 10, 1, 5),
+     datetime(2024, 10, 2, 5), []),
+    ('no-notifications', datetime(2024, 10, 1, 5),
+     datetime(2024, 10, 31, 5), None)
+])
+def test_over_payment_notification_unlinked(session, test_name, created_on_date, execution_date, assert_calls_override):
+    """Assert notification is being sent for unlinked accounts."""
+    unlinked_shortname, inactive_link_shortname, _ = create_unlinked_short_names_data(
+        created_on_date)
+    with patch('tasks.eft_overpayment_notification_task.send_email') as mock_mailer:
+        with patch('tasks.eft_overpayment_notification_task.get_emails_with_keycloak_role', ) as mock_auth:
+            expected_email = 'test@email.com'
+            expected_subject = 'Pending Unsettled Amount for Short Name'
+            mock_auth.return_value = expected_email
+            with freeze_time(execution_date):
+                EFTOverpaymentNotificationTask.process_overpayment_notification()
+                expected_calls = [
+                    call(recipients=expected_email,
+                         subject=f'{expected_subject} {unlinked_shortname.short_name}',
+                         body=ANY),
+                    call(recipients=expected_email,
+                         subject=f'{expected_subject} {inactive_link_shortname.short_name}',
+                         body=ANY),
+                ] if assert_calls_override is None else []
+            mock_mailer.assert_has_calls(expected_calls, any_order=True)
+            assert mock_mailer.call_count == len(expected_calls)
+
+
+def test_over_payment_notification_linked(session):
+    """Assert notification is being sent for linked accounts."""
+    linked_shortname, _ = create_linked_short_names_data(
+        datetime(2024, 10, 1, 5))
+    with patch('tasks.eft_overpayment_notification_task.send_email') as mock_mailer:
+        with patch('tasks.eft_overpayment_notification_task.get_emails_with_keycloak_role', ) as mock_auth:
+            expected_email = 'test@email.com'
+            expected_subject = 'Pending Unsettled Amount for Short Name'
+            mock_auth.return_value = expected_email
+            with freeze_time(datetime(2024, 10, 1, 7)):
+                EFTOverpaymentNotificationTask.process_overpayment_notification()
+                expected_calls = [
+                    call(recipients=expected_email,
+                         subject=f'{expected_subject} {linked_shortname.short_name}',
+                         body=ANY),
+                ]
+            mock_mailer.assert_has_calls(expected_calls, any_order=True)
+            assert mock_mailer.call_count == len(expected_calls)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/21516

*Description of changes:*
- rename statement_due_task to eft_statement_due_task for clarity
- eft_overpayment_notification_task job for unlinked accounts with credits remaining for 30 days and linked over payments


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
