### PR TITLE
Fix code scanning alert no. 5: Reflected server-side cross-site scripting

### DIFF
--- a/pay-api/src/pay_api/resources/v1/fas/routing_slip.py
+++ b/pay-api/src/pay_api/resources/v1/fas/routing_slip.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Resource for Account payments endpoints."""
+import re
 from http import HTTPStatus
 
 from flask import Blueprint, Response, current_app, jsonify, request
-import re
 from flask_cors import cross_origin
 
 from pay_api.exceptions import BusinessException, ServiceUnavailableException, error_to_response
@@ -88,8 +88,8 @@ def post_routing_slip_report(date: str):
     current_app.logger.info("<post_routing_slip_report")
 
     # Validate the date parameter to ensure it matches the expected format (YYYY-MM-DD)
-    if not re.match(r'^\d{4}-\d{2}-\d{2}$', date):
-        return error_to_response(Error.INVALID_REQUEST, message="Invalid date format. Expected YYYY-MM-DD.")
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", date):
+        return error_to_response(Error.INVALID_REQUEST, invalid_params=["date"])
 
     pdf, file_name = RoutingSlipService.create_daily_reports(date)
 

--- a/pay-api/src/pay_api/resources/v1/fas/routing_slip.py
+++ b/pay-api/src/pay_api/resources/v1/fas/routing_slip.py
@@ -15,6 +15,7 @@
 from http import HTTPStatus
 
 from flask import Blueprint, Response, current_app, jsonify, request
+import re
 from flask_cors import cross_origin
 
 from pay_api.exceptions import BusinessException, ServiceUnavailableException, error_to_response
@@ -85,6 +86,10 @@ def post_search_routing_slips():
 def post_routing_slip_report(date: str):
     """Create routing slip report."""
     current_app.logger.info("<post_routing_slip_report")
+
+    # Validate the date parameter to ensure it matches the expected format (YYYY-MM-DD)
+    if not re.match(r'^\d{4}-\d{2}-\d{2}$', date):
+        return error_to_response(Error.INVALID_REQUEST, message="Invalid date format. Expected YYYY-MM-DD.")
 
     pdf, file_name = RoutingSlipService.create_daily_reports(date)
 

--- a/pay-api/src/pay_api/utils/enums.py
+++ b/pay-api/src/pay_api/utils/enums.py
@@ -374,11 +374,11 @@ class EFTShortnameStatus(Enum):
 class EFTShortnameRefundStatus(Enum):
     """EFT Short name refund statuses."""
 
-    APPROVED = 'APPROVED'
-    PENDING_APPROVAL = 'PENDING_APPROVAL'
-    DECLINED = 'DECLINED'
-    COMPLETED = 'COMPLETED'
-    ERRORED = 'ERRORED'
+    APPROVED = "APPROVED"
+    PENDING_APPROVAL = "PENDING_APPROVAL"
+    DECLINED = "DECLINED"
+    COMPLETED = "COMPLETED"
+    ERRORED = "ERRORED"
 
 
 class EFTPaymentActions(Enum):


### PR DESCRIPTION
Fixes [https://github.com/bcgov/sbc-pay/security/code-scanning/5](https://github.com/bcgov/sbc-pay/security/code-scanning/5)

To fix the problem, we need to ensure that the `date` parameter is properly sanitized before it is used to generate the `pdf` content. This can be done by validating the `date` parameter to ensure it conforms to an expected format (e.g., YYYY-MM-DD) before passing it to the `RoutingSlipService.create_daily_reports` method.

1. Import the `re` module for regular expression matching.
2. Add a validation step for the `date` parameter to ensure it matches the expected date format.
3. If the `date` parameter is invalid, return an appropriate error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
