### PR TITLE
Fix references to sbc-common-components to use new camelCase serialization

### DIFF
--- a/bcol-api/poetry.lock
+++ b/bcol-api/poetry.lock
@@ -1639,7 +1639,7 @@ jaeger-client = "*"
 type = "git"
 url = "https://github.com/bcgov/sbc-common-components.git"
 reference = "HEAD"
-resolved_reference = "22978d810dc4e85c51c3129936686b0a17124e64"
+resolved_reference = "d640dc75ea51add2d611a30259d15d93d8654381"
 subdirectory = "python"
 
 [[package]]

--- a/jobs/ftp-poller/poetry.lock
+++ b/jobs/ftp-poller/poetry.lock
@@ -2715,7 +2715,7 @@ jaeger-client = "*"
 type = "git"
 url = "https://github.com/bcgov/sbc-common-components.git"
 reference = "HEAD"
-resolved_reference = "22978d810dc4e85c51c3129936686b0a17124e64"
+resolved_reference = "d640dc75ea51add2d611a30259d15d93d8654381"
 subdirectory = "python"
 
 [[package]]

--- a/pay-api/poetry.lock
+++ b/pay-api/poetry.lock
@@ -2387,7 +2387,7 @@ jaeger-client = "*"
 type = "git"
 url = "https://github.com/bcgov/sbc-common-components.git"
 reference = "HEAD"
-resolved_reference = "22978d810dc4e85c51c3129936686b0a17124e64"
+resolved_reference = "d640dc75ea51add2d611a30259d15d93d8654381"
 subdirectory = "python"
 
 [[package]]

--- a/pay-api/tests/unit/api/fas/test_routing_slip.py
+++ b/pay-api/tests/unit/api/fas/test_routing_slip.py
@@ -257,7 +257,7 @@ def test_link_routing_slip_invalid_status(session, client, jwt, app):
     client.post("/api/v1/fas/routing-slips", data=json.dumps(child1), headers=headers)
 
     rv = client.get(f"/api/v1/fas/routing-slips/{child.get('number')}/links", headers=headers)
-    assert rv.json.get("parent") is None
+    assert rv.json.get("parent") == {}
 
     rv = client.patch(
         f"/api/v1/fas/routing-slips/{child.get('number')}?action={PatchActions.UPDATE_STATUS.value}",
@@ -314,7 +314,7 @@ def test_link_routing_slip(session, client, jwt, app):
     client.post("/api/v1/fas/routing-slips", data=json.dumps(parent), headers=headers)
 
     rv = client.get(f"/api/v1/fas/routing-slips/{child.get('number')}/links", headers=headers)
-    assert rv.json.get("parent") is None
+    assert rv.json.get("parent") == {}
 
     # attempt to link NSF, should fail
     nsf = get_routing_slip_request("933458069")


### PR DESCRIPTION
https://github.com/bcgov/sbc-common-components/pull/375

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
