### PR TITLE
24174- Handling statement template invoices with no payment date

### DIFF
--- a/pay-api/src/pay_api/services/statement.py
+++ b/pay-api/src/pay_api/services/statement.py
@@ -358,9 +358,10 @@ class Statement:  # pylint:disable=too-many-public-methods
 
         latest_payment_date = None
         for invoice in statement_invoices:
-            if invoice.payment_date is not None:
-                if latest_payment_date is None or invoice.payment_date > latest_payment_date:
-                    latest_payment_date = invoice.payment_date
+            if invoice.payment_date is None:
+                continue
+            if latest_payment_date is None or invoice.payment_date > latest_payment_date:
+                latest_payment_date = invoice.payment_date
 
         return {
             "lastStatementTotal": previous_totals["fees"] if previous_totals else 0,


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/24174

*Description of changes:*
Fixed an issue with the template not generating when there is no payment date on an invoice.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
