### PR TITLE
25596 - EFT Locking Fixes

### DIFF
--- a/jobs/payment-jobs/tasks/eft_statement_due_task.py
+++ b/jobs/payment-jobs/tasks/eft_statement_due_task.py
@@ -110,7 +110,7 @@ class EFTStatementDueTask:  # pylint: disable=too-few-public-methods
             InvoiceModel.overdue_date.isnot(None),
             InvoiceModel.overdue_date <= now,
             InvoiceModel.invoice_status_code.in_(cls.unpaid_status),
-            )
+        )
         if cls.auth_account_override:
             current_app.logger.info(f"Using auth account override for auth_account_id: {cls.auth_account_override}")
             payment_account_id = (
@@ -127,10 +127,7 @@ class EFTStatementDueTask:  # pylint: disable=too-few-public-methods
 
         # Check for overdue accounts and lock them
         overdue_query = (
-            select(
-                PaymentAccountModel,
-                StatementModel
-            )
+            select(PaymentAccountModel, StatementModel)
             .select_from(InvoiceModel)
             .join(PaymentAccountModel, PaymentAccountModel.id == InvoiceModel.payment_account_id)
             .join(StatementInvoicesModel, StatementInvoicesModel.invoice_id == InvoiceModel.id)
@@ -139,7 +136,7 @@ class EFTStatementDueTask:  # pylint: disable=too-few-public-methods
                 InvoiceModel.payment_method_code == PaymentMethod.EFT.value,
                 InvoiceModel.invoice_status_code == InvoiceStatus.OVERDUE.value,
                 InvoiceModel.overdue_date <= now,
-                StatementModel.overdue_notification_date.is_(None)
+                StatementModel.overdue_notification_date.is_(None),
             )
             .group_by(PaymentAccountModel.id, StatementModel.id)
         )

--- a/jobs/payment-jobs/tasks/eft_statement_due_task.py
+++ b/jobs/payment-jobs/tasks/eft_statement_due_task.py
@@ -28,12 +28,12 @@ from pay_api.models.statement import Statement as StatementModel
 from pay_api.models.statement_invoices import StatementInvoices as StatementInvoicesModel
 from pay_api.models.statement_recipients import StatementRecipients as StatementRecipientsModel
 from pay_api.services import NonSufficientFundsService
-from pay_api.services.flags import flags
 from pay_api.services.statement import Statement
 from pay_api.services.statement_settings import StatementSettings as StatementSettingsService
 from pay_api.utils.enums import InvoiceStatus, PaymentMethod, StatementFrequency
 from pay_api.utils.util import current_local_time
 from sentry_sdk import capture_message
+from sqlalchemy import select
 
 from utils.auth_event import AuthEvent
 from utils.enums import StatementNotificationAction
@@ -86,16 +86,14 @@ class EFTStatementDueTask:  # pylint: disable=too-few-public-methods
         statement_date_override=None,
     ):
         """Notify for unpaid statements with an amount owing."""
-        eft_enabled = flags.is_on("enable-eft-payment-method", default=False)
-        if eft_enabled:
-            cls.auth_account_override = auth_account_override
-            cls.statement_date_override = statement_date_override
+        cls.auth_account_override = auth_account_override
+        cls.statement_date_override = statement_date_override
 
-            if action_override is not None and len(action_override.strip()) > 0:
-                cls.process_override_command(action_override, date_override)
-            else:
-                cls._update_invoice_overdue_status()
-                cls._notify_for_monthly()
+        if action_override is not None and len(action_override.strip()) > 0:
+            cls.process_override_command(action_override, date_override)
+        else:
+            cls._update_invoice_overdue_status()
+            cls._notify_for_monthly()
 
     @classmethod
     def _update_invoice_overdue_status(cls):
@@ -112,7 +110,7 @@ class EFTStatementDueTask:  # pylint: disable=too-few-public-methods
             InvoiceModel.overdue_date.isnot(None),
             InvoiceModel.overdue_date <= now,
             InvoiceModel.invoice_status_code.in_(cls.unpaid_status),
-        )
+            )
         if cls.auth_account_override:
             current_app.logger.info(f"Using auth account override for auth_account_id: {cls.auth_account_override}")
             payment_account_id = (
@@ -126,6 +124,53 @@ class EFTStatementDueTask:  # pylint: disable=too-few-public-methods
             synchronize_session="fetch",
         )
         db.session.commit()
+
+        # Check for overdue accounts and lock them
+        overdue_query = (
+            select(
+                PaymentAccountModel,
+                StatementModel
+            )
+            .select_from(InvoiceModel)
+            .join(PaymentAccountModel, PaymentAccountModel.id == InvoiceModel.payment_account_id)
+            .join(StatementInvoicesModel, StatementInvoicesModel.invoice_id == InvoiceModel.id)
+            .join(StatementModel, StatementModel.id == StatementInvoicesModel.statement_id)
+            .filter(
+                InvoiceModel.payment_method_code == PaymentMethod.EFT.value,
+                InvoiceModel.invoice_status_code == InvoiceStatus.OVERDUE.value,
+                InvoiceModel.overdue_date <= now,
+                StatementModel.overdue_notification_date.is_(None)
+            )
+            .group_by(PaymentAccountModel.id, StatementModel.id)
+        )
+        if cls.auth_account_override:
+            overdue_query = overdue_query.filter(PaymentAccountModel.auth_account_id == cls.auth_account_override)
+
+        overdue_results = db.session.execute(overdue_query)
+        accounts_to_lock = {}
+        # Update statement overdue_notification_date and collect accounts so we don't lock it multiple times
+        for payment_account, overdue_statement in overdue_results:
+            accounts_to_lock[payment_account.id] = payment_account
+            overdue_statement.overdue_notification_date = datetime.now(tz=timezone.utc)
+            overdue_statement.save()
+
+        for _, payment_account in accounts_to_lock.items():
+            current_app.logger.info(
+                "Freezing payment account id: %s locking auth account id: %s",
+                payment_account.id,
+                payment_account.auth_account_id,
+            )
+
+            # Only publish lock event if it is not already locked
+            if payment_account.has_overdue_invoices is None:
+                additional_emails = current_app.config.get("EFT_OVERDUE_NOTIFY_EMAILS")
+                AuthEvent.publish_lock_account_event(payment_account, additional_emails)
+
+            # Even if the account is locked, there is a new overdue statement that needs NSF invoices added and
+            # set the most recent date for has_overdue_invoices
+            payment_account.has_overdue_invoices = datetime.now(tz=timezone.utc)
+            payment_account.save()
+            cls.add_to_non_sufficient_funds(payment_account)
 
     @classmethod
     def add_to_non_sufficient_funds(cls, payment_account):
@@ -186,22 +231,6 @@ class EFTStatementDueTask:  # pylint: disable=too-few-public-methods
                 action, due_date = cls._determine_action_and_due_date_by_invoice(statement)
                 total_due = Statement.get_summary(payment_account.auth_account_id, statement.id)["total_due"]
                 if action and total_due > 0:
-                    if action == StatementNotificationAction.OVERDUE:
-                        current_app.logger.info(
-                            "Freezing payment account id: %s locking auth account id: %s",
-                            payment_account.id,
-                            payment_account.auth_account_id,
-                        )
-                        # The locking email is sufficient for overdue, no seperate email required.
-                        additional_emails = current_app.config.get("EFT_OVERDUE_NOTIFY_EMAILS")
-                        AuthEvent.publish_lock_account_event(payment_account, additional_emails)
-                        statement.overdue_notification_date = datetime.now(tz=timezone.utc)
-                        # Saving here because the code below can exception, we don't want to send the lock email twice.
-                        statement.save()
-                        payment_account.has_overdue_invoices = datetime.now(tz=timezone.utc)
-                        payment_account.save()
-                        cls.add_to_non_sufficient_funds(payment_account)
-                        continue
                     if emails := cls._determine_recipient_emails(statement):
                         current_app.logger.info(
                             f"Sending statement {statement.id} {action}"
@@ -279,8 +308,6 @@ class EFTStatementDueTask:  # pylint: disable=too-few-public-methods
         else:
             now_date = datetime.now(tz=timezone.utc).replace(tzinfo=None).date()
 
-        if invoice.invoice_status_code == InvoiceStatus.OVERDUE.value:
-            return StatementNotificationAction.OVERDUE, day_invoice_due
         if day_invoice_due == now_date:
             return StatementNotificationAction.DUE, day_invoice_due
         if seven_days_before_invoice_due == now_date:

--- a/jobs/payment-jobs/tests/jobs/test_eft_statement_due_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_eft_statement_due_task.py
@@ -259,7 +259,7 @@ def test_account_lock(setup, session):
     assert invoices3[0].invoice_id == invoice3.id
 
     with patch("utils.auth_event.AuthEvent.publish_lock_account_event") as mock_auth_event:
-        with patch("tasks.eft_statement_due_task.publish_payment_notification") as mock_mailer:
+        with patch("tasks.eft_statement_due_task.publish_payment_notification"):
             EFTStatementDueTask.process_unpaid_statements()
             # Already locked we should not be publishing another event
             mock_auth_event.assert_not_called()
@@ -316,7 +316,7 @@ def test_multi_account_lock(setup, session):
     assert invoices2[0].invoice_id == invoice2.id
 
     with patch("utils.auth_event.AuthEvent.publish_lock_account_event") as mock_auth_event:
-        with patch("tasks.eft_statement_due_task.publish_payment_notification") as mock_mailer:
+        with patch("tasks.eft_statement_due_task.publish_payment_notification"):
             EFTStatementDueTask.process_unpaid_statements()
             mock_auth_event.call_count == 2
             expected_calls = [call(account1, ""), call(account2, "")]

--- a/jobs/payment-jobs/tests/jobs/test_eft_statement_due_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_eft_statement_due_task.py
@@ -18,7 +18,7 @@ Test-Suite to ensure that the UnpaidStatementNotifyTask is working as expected.
 """
 import decimal
 from datetime import datetime
-from unittest.mock import patch, ANY, call
+from unittest.mock import ANY, call, patch
 
 import pytest
 from dateutil.relativedelta import relativedelta
@@ -65,7 +65,7 @@ def create_test_data(
     statement_frequency: str,
     invoice_total: decimal = 0.00,
     invoice_paid: decimal = 0.00,
-    auth_account_id="1"
+    auth_account_id="1",
 ):
     """Create seed data for tests."""
     account = factory_create_account(auth_account_id=auth_account_id, payment_method_code=payment_method_code)
@@ -200,7 +200,7 @@ def test_account_lock(setup, session):
         payment_date=datetime(2023, 1, 1, 8),
         statement_frequency=StatementFrequency.MONTHLY.value,
         invoice_total=351.50,
-        auth_account_id="1"
+        auth_account_id="1",
     )
 
     # For second statement on account 1
@@ -209,7 +209,7 @@ def test_account_lock(setup, session):
         created_on=datetime(2023, 2, 5, 8),
         payment_method_code=PaymentMethod.EFT.value,
         status_code=InvoiceStatus.APPROVED.value,
-        total=100
+        total=100,
     )
     factory_invoice_reference(invoice_id=invoice2.id)
 
@@ -232,7 +232,7 @@ def test_account_lock(setup, session):
         with patch("tasks.eft_statement_due_task.publish_payment_notification") as mock_mailer:
             EFTStatementDueTask.process_unpaid_statements()
             mock_auth_event.assert_called_once()
-            expected_calls = [call(account1, '')]
+            expected_calls = [call(account1, "")]
             mock_auth_event.assert_has_calls(expected_calls, any_order=True)
             assert account1.has_overdue_invoices
             assert statements[0][0].overdue_notification_date
@@ -246,7 +246,7 @@ def test_account_lock(setup, session):
         created_on=datetime(2023, 3, 5, 8),
         payment_method_code=PaymentMethod.EFT.value,
         status_code=InvoiceStatus.APPROVED.value,
-        total=120
+        total=120,
     )
     factory_invoice_reference(invoice_id=invoice3.id)
 
@@ -275,7 +275,7 @@ def test_multi_account_lock(setup, session):
         payment_date=datetime(2023, 1, 1, 8),
         statement_frequency=StatementFrequency.MONTHLY.value,
         invoice_total=351.50,
-        auth_account_id="1"
+        auth_account_id="1",
     )
 
     # For second statement on account 1
@@ -284,7 +284,7 @@ def test_multi_account_lock(setup, session):
         created_on=datetime(2023, 2, 5, 8),
         payment_method_code=PaymentMethod.EFT.value,
         status_code=InvoiceStatus.APPROVED.value,
-        total=100
+        total=100,
     )
     factory_invoice_reference(invoice_id=invoice1a.id)
 
@@ -293,7 +293,7 @@ def test_multi_account_lock(setup, session):
         payment_date=datetime(2023, 1, 10, 8),
         statement_frequency=StatementFrequency.MONTHLY.value,
         invoice_total=150.50,
-        auth_account_id=2
+        auth_account_id=2,
     )
 
     with freeze_time(datetime(2023, 2, 1, 8, 0, 1)):
@@ -319,7 +319,7 @@ def test_multi_account_lock(setup, session):
         with patch("tasks.eft_statement_due_task.publish_payment_notification") as mock_mailer:
             EFTStatementDueTask.process_unpaid_statements()
             mock_auth_event.call_count == 2
-            expected_calls = [call(account1, ''), call(account2, '')]
+            expected_calls = [call(account1, ""), call(account2, "")]
             mock_auth_event.assert_has_calls(expected_calls, any_order=True)
             assert statements1[0][1].overdue_notification_date
             assert NonSufficientFundsModel.find_by_invoice_id(invoice1.id)

--- a/jobs/payment-jobs/tests/jobs/test_eft_statement_due_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_eft_statement_due_task.py
@@ -18,7 +18,7 @@ Test-Suite to ensure that the UnpaidStatementNotifyTask is working as expected.
 """
 import decimal
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import patch, ANY, call
 
 import pytest
 from dateutil.relativedelta import relativedelta
@@ -65,9 +65,10 @@ def create_test_data(
     statement_frequency: str,
     invoice_total: decimal = 0.00,
     invoice_paid: decimal = 0.00,
+    auth_account_id="1"
 ):
     """Create seed data for tests."""
-    account = factory_create_account(auth_account_id="1", payment_method_code=payment_method_code)
+    account = factory_create_account(auth_account_id=auth_account_id, payment_method_code=payment_method_code)
     invoice = factory_invoice(
         payment_account=account,
         created_on=payment_date,
@@ -190,6 +191,142 @@ def test_overdue_invoices_updated(setup, session):
     EFTStatementDueTask.process_unpaid_statements(auth_account_override=account.auth_account_id)
     assert invoice.invoice_status_code == InvoiceStatus.OVERDUE.value
     assert invoice2.invoice_status_code == InvoiceStatus.APPROVED.value
+
+
+def test_account_lock(setup, session):
+    """Assert account locking on overdue statements."""
+    account1, invoice1, _, statement_recipient1, _ = create_test_data(
+        payment_method_code=PaymentMethod.EFT.value,
+        payment_date=datetime(2023, 1, 1, 8),
+        statement_frequency=StatementFrequency.MONTHLY.value,
+        invoice_total=351.50,
+        auth_account_id="1"
+    )
+
+    # For second statement on account 1
+    invoice2 = factory_invoice(
+        payment_account=account1,
+        created_on=datetime(2023, 2, 5, 8),
+        payment_method_code=PaymentMethod.EFT.value,
+        status_code=InvoiceStatus.APPROVED.value,
+        total=100
+    )
+    factory_invoice_reference(invoice_id=invoice2.id)
+
+    # Confirm locking works for non recent statements
+    with freeze_time(datetime(2023, 2, 1, 8, 0, 1)):
+        StatementTask.generate_statements()
+
+    with freeze_time(datetime(2023, 3, 1, 8, 0, 1)):
+        StatementTask.generate_statements()
+
+    statements = StatementService.get_account_statements(auth_account_id=account1.auth_account_id, page=1, limit=100)
+    invoices1 = StatementInvoicesModel.find_all_invoices_for_statement(statements[0][1].id)
+    invoices2 = StatementInvoicesModel.find_all_invoices_for_statement(statements[0][0].id)
+    assert invoices1 is not None
+    assert invoices1[0].invoice_id == invoice1.id
+    assert invoices2 is not None
+    assert invoices2[0].invoice_id == invoice2.id
+
+    with patch("utils.auth_event.AuthEvent.publish_lock_account_event") as mock_auth_event:
+        with patch("tasks.eft_statement_due_task.publish_payment_notification") as mock_mailer:
+            EFTStatementDueTask.process_unpaid_statements()
+            mock_auth_event.assert_called_once()
+            expected_calls = [call(account1, '')]
+            mock_auth_event.assert_has_calls(expected_calls, any_order=True)
+            assert account1.has_overdue_invoices
+            assert statements[0][0].overdue_notification_date
+            assert NonSufficientFundsModel.find_by_invoice_id(invoice1.id)
+            assert statements[0][1].overdue_notification_date
+            assert NonSufficientFundsModel.find_by_invoice_id(invoice2.id)
+
+    # Create 3rd statement, account is already locked but this statement should still have NSF invoices records added
+    invoice3 = factory_invoice(
+        payment_account=account1,
+        created_on=datetime(2023, 3, 5, 8),
+        payment_method_code=PaymentMethod.EFT.value,
+        status_code=InvoiceStatus.APPROVED.value,
+        total=120
+    )
+    factory_invoice_reference(invoice_id=invoice3.id)
+
+    with freeze_time(datetime(2023, 4, 1, 8, 0, 1)):
+        StatementTask.generate_statements()
+
+    statements = StatementService.get_account_statements(auth_account_id=account1.auth_account_id, page=1, limit=100)
+    invoices3 = StatementInvoicesModel.find_all_invoices_for_statement(statements[0][0].id)
+    assert invoices3 is not None
+    assert invoices3[0].invoice_id == invoice3.id
+
+    with patch("utils.auth_event.AuthEvent.publish_lock_account_event") as mock_auth_event:
+        with patch("tasks.eft_statement_due_task.publish_payment_notification") as mock_mailer:
+            EFTStatementDueTask.process_unpaid_statements()
+            # Already locked we should not be publishing another event
+            mock_auth_event.assert_not_called()
+            assert account1.has_overdue_invoices
+            assert statements[0][0].overdue_notification_date
+            assert NonSufficientFundsModel.find_by_invoice_id(invoice3.id)
+
+
+def test_multi_account_lock(setup, session):
+    """Assert multi account locking on overdue statements."""
+    account1, invoice1, _, statement_recipient1, _ = create_test_data(
+        payment_method_code=PaymentMethod.EFT.value,
+        payment_date=datetime(2023, 1, 1, 8),
+        statement_frequency=StatementFrequency.MONTHLY.value,
+        invoice_total=351.50,
+        auth_account_id="1"
+    )
+
+    # For second statement on account 1
+    invoice1a = factory_invoice(
+        payment_account=account1,
+        created_on=datetime(2023, 2, 5, 8),
+        payment_method_code=PaymentMethod.EFT.value,
+        status_code=InvoiceStatus.APPROVED.value,
+        total=100
+    )
+    factory_invoice_reference(invoice_id=invoice1a.id)
+
+    account2, invoice2, _, statement_recipient2, _ = create_test_data(
+        payment_method_code=PaymentMethod.EFT.value,
+        payment_date=datetime(2023, 1, 10, 8),
+        statement_frequency=StatementFrequency.MONTHLY.value,
+        invoice_total=150.50,
+        auth_account_id=2
+    )
+
+    with freeze_time(datetime(2023, 2, 1, 8, 0, 1)):
+        StatementTask.generate_statements()
+
+    with freeze_time(datetime(2023, 3, 1, 8, 0, 1)):
+        StatementTask.generate_statements()
+
+    statements1 = StatementService.get_account_statements(auth_account_id=account1.auth_account_id, page=1, limit=100)
+    invoices1 = StatementInvoicesModel.find_all_invoices_for_statement(statements1[0][1].id)
+    invoices1a = StatementInvoicesModel.find_all_invoices_for_statement(statements1[0][0].id)
+    assert invoices1 is not None
+    assert invoices1[0].invoice_id == invoice1.id
+    assert invoices1a is not None
+    assert invoices1a[0].invoice_id == invoice1a.id
+
+    statements2 = StatementService.get_account_statements(auth_account_id=account2.auth_account_id, page=1, limit=100)
+    invoices2 = StatementInvoicesModel.find_all_invoices_for_statement(statements2[0][1].id)
+    assert invoices2 is not None
+    assert invoices2[0].invoice_id == invoice2.id
+
+    with patch("utils.auth_event.AuthEvent.publish_lock_account_event") as mock_auth_event:
+        with patch("tasks.eft_statement_due_task.publish_payment_notification") as mock_mailer:
+            EFTStatementDueTask.process_unpaid_statements()
+            mock_auth_event.call_count == 2
+            expected_calls = [call(account1, ''), call(account2, '')]
+            mock_auth_event.assert_has_calls(expected_calls, any_order=True)
+            assert statements1[0][1].overdue_notification_date
+            assert NonSufficientFundsModel.find_by_invoice_id(invoice1.id)
+            assert account1.has_overdue_invoices
+            assert statements2[0][1].overdue_notification_date
+            assert NonSufficientFundsModel.find_by_invoice_id(invoice2.id)
+            assert account2.has_overdue_invoices
 
 
 @pytest.mark.parametrize(

--- a/jobs/payment-jobs/tests/jobs/test_eft_statement_due_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_eft_statement_due_task.py
@@ -229,7 +229,7 @@ def test_account_lock(setup, session):
     assert invoices2[0].invoice_id == invoice2.id
 
     with patch("utils.auth_event.AuthEvent.publish_lock_account_event") as mock_auth_event:
-        with patch("tasks.eft_statement_due_task.publish_payment_notification") as mock_mailer:
+        with patch("tasks.eft_statement_due_task.publish_payment_notification"):
             EFTStatementDueTask.process_unpaid_statements()
             mock_auth_event.assert_called_once()
             expected_calls = [call(account1, "")]


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/25596
*Description of changes:*
- Update so locking mechanism doesn't just look at the most recent statement (cover the case where we manually defer the overdue date in the db)
- Updated to handle multiple overdue statements
- Updated to properly evaluate new overdue invoices even on a currently locked account and properly add NSF invoice records and update statement.has_overdue_invoices date
- Expanded logic to prevent locking an account multiple times in the same job run or subsequent job runs when an account is already locked


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
