### PR TITLE
26465 - EFT Shortname history update / migration data fix

### DIFF
--- a/pay-api/migrations/versions/2025_03_17_f6e2fd9710b7_26465_eft_refund_data_fix.py
+++ b/pay-api/migrations/versions/2025_03_17_f6e2fd9710b7_26465_eft_refund_data_fix.py
@@ -1,0 +1,28 @@
+"""26465 - EFT Refund data fix for existing refunds
+
+Revision ID: f6e2fd9710b7
+Revises: 48f199450139
+Create Date: 2025-03-17 10:09:39.847650
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from pay_api.utils.enums import APRefundMethod
+
+revision = 'f6e2fd9710b7'
+down_revision = '48f199450139'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        f"update eft_refunds set refund_method='{APRefundMethod.EFT.value}' where refund_method is null"
+    )
+
+
+def downgrade():
+    op.execute(
+        f"update eft_refunds set refund_method=null where refund_method='{APRefundMethod.EFT.value}'"
+    )

--- a/pay-api/src/pay_api/models/eft_short_names_historical.py
+++ b/pay-api/src/pay_api/models/eft_short_names_historical.py
@@ -95,6 +95,8 @@ class EFTShortnameHistorySchema:  # pylint: disable=too-few-public-methods
     amount: Decimal
     invoice_id: int
     eft_refund_id: int
+    eft_refund_method: str
+    eft_refund_cheque_status: str
     statement_number: int
     short_name_id: int
     short_name_balance: Decimal
@@ -119,6 +121,8 @@ class EFTShortnameHistorySchema:  # pylint: disable=too-few-public-methods
             account_branch=getattr(row, "account_branch", None),
             invoice_id=getattr(row, "invoice_id", None),
             eft_refund_id=getattr(row, "eft_refund_id", None),
+            eft_refund_method=getattr(row, "refund_method", None),
+            eft_refund_cheque_status=getattr(row, "cheque_status", None),
             statement_number=getattr(row, "statement_number", None),
             transaction_date=getattr(row, "transaction_date", None),
             transaction_type=getattr(row, "transaction_type", None),

--- a/pay-api/src/pay_api/services/eft_short_name_historical.py
+++ b/pay-api/src/pay_api/services/eft_short_name_historical.py
@@ -20,6 +20,7 @@ from typing import Optional
 from sqlalchemy import and_, case, exists, false, func, select
 from sqlalchemy.orm import aliased
 
+from pay_api.models import EFTRefund as EFTRefundModel
 from pay_api.models import EFTShortnameHistorySchema
 from pay_api.models import EFTShortnamesHistorical as EFTShortnamesHistoricalModel
 from pay_api.models import PaymentAccount as PaymentAccountModel
@@ -231,11 +232,14 @@ class EFTShortnameHistorical:
                 cls._get_account_name(),
                 PaymentAccountModel.branch_name.label("account_branch"),
                 is_reversible_statement.label("is_reversible"),
+                EFTRefundModel.refund_method,
+                EFTRefundModel.cheque_status,
             )
             .outerjoin(
                 PaymentAccountModel,
                 PaymentAccountModel.id == history_model.payment_account_id,
             )
+            .outerjoin(EFTRefundModel, EFTRefundModel.id == history_model.eft_refund_id)
             .filter(history_model.short_name_id == short_name_id)
             .filter(history_model.hidden == false())
         )

--- a/pay-api/tests/utilities/base_test.py
+++ b/pay-api/tests/utilities/base_test.py
@@ -52,7 +52,9 @@ from pay_api.models import (
 from pay_api.models.partner_disbursements import PartnerDisbursements
 from pay_api.utils.constants import DT_SHORT_FORMAT
 from pay_api.utils.enums import (
+    APRefundMethod,
     CfsAccountStatus,
+    ChequeRefundStatus,
     DisbursementStatus,
     EFTHistoricalTypes,
     EFTShortnameStatus,
@@ -972,9 +974,12 @@ def factory_eft_refund(
     status="PENDING",
     decline_reason=None,
     created_by="TEST_USER",
+    refund_method=APRefundMethod.CHEQUE.value,
+    cheque_status=ChequeRefundStatus.PROCESSING.value,
 ):
     """Return an EFT Refund."""
     return EFTRefund(
+        refund_method=refund_method,
         created_by=created_by,
         decline_reason=decline_reason,
         short_name_id=short_name_id,
@@ -984,6 +989,7 @@ def factory_eft_refund(
         refund_email=refund_email,
         comment=comment,
         status=status,
+        cheque_status=cheque_status,
     ).save()
 
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/26465

*Description of changes:*
- add refund method and cheque status for eft short name history
- data fix for existing refunds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
