### PR TITLE
15674 - Add invoice_number as params to PAD confirmation email

### DIFF
--- a/jobs/payment-jobs/tasks/cfs_create_invoice_task.py
+++ b/jobs/payment-jobs/tasks/cfs_create_invoice_task.py
@@ -361,6 +361,7 @@ class CreateInvoiceTask:  # pylint:disable=too-few-public-methods
                 "credit_total": float(credit_total),
                 "invoice_total": float(invoice_total),
                 "invoice_process_date": f"{datetime.now(tz=timezone.utc)}",
+                "invoice_number": invoice_response.get("invoice_number"),
             }
 
             mailer.publish_mailer_events(

--- a/jobs/payment-jobs/tests/jobs/test_cfs_create_invoice_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_cfs_create_invoice_task.py
@@ -17,7 +17,7 @@
 Test-Suite to ensure that the CreateInvoiceTask is working as expected.
 """
 from datetime import datetime, timedelta, timezone
-from unittest.mock import call, patch
+from unittest.mock import call, patch, ANY
 
 from freezegun import freeze_time
 from pay_api.models import Credit as CreditModel
@@ -109,14 +109,13 @@ def test_create_pad_invoice_mixed_pli_values(session):
     line.save()
     CreditModel(account_id=account.id, amount=1, remaining_amount=1).save()
     assert invoice.invoice_status_code == InvoiceStatus.APPROVED.value
-    inv_ref = factory_invoice_reference(invoice.id)
 
     now = datetime.now(tz=timezone.utc)
     additional_params = {
         "credit_total": 1,
         "invoice_total": 1.5,
         "invoice_process_date": f"{now}",
-        "invoice_number": f"{inv_ref.invoice_number}",
+        "invoice_number": ANY
     }
     with freeze_time(now):
         with patch("utils.mailer.publish_mailer_events") as mock_publish_mailer_events:

--- a/jobs/payment-jobs/tests/jobs/test_cfs_create_invoice_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_cfs_create_invoice_task.py
@@ -40,6 +40,7 @@ from .factory import (
     factory_create_online_banking_account,
     factory_create_pad_account,
     factory_invoice,
+    factory_invoice_reference,
     factory_payment_line_item,
     factory_routing_slip_account,
 )
@@ -108,12 +109,14 @@ def test_create_pad_invoice_mixed_pli_values(session):
     line.save()
     CreditModel(account_id=account.id, amount=1, remaining_amount=1).save()
     assert invoice.invoice_status_code == InvoiceStatus.APPROVED.value
+    inv_ref = factory_invoice_reference(invoice.id)
 
     now = datetime.now(tz=timezone.utc)
     additional_params = {
         "credit_total": 1,
         "invoice_total": 1.5,
         "invoice_process_date": f"{now}",
+        "invoice_number": f"{inv_ref.invoice_number}",
     }
     with freeze_time(now):
         with patch("utils.mailer.publish_mailer_events") as mock_publish_mailer_events:

--- a/jobs/payment-jobs/tests/jobs/test_cfs_create_invoice_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_cfs_create_invoice_task.py
@@ -17,7 +17,7 @@
 Test-Suite to ensure that the CreateInvoiceTask is working as expected.
 """
 from datetime import datetime, timedelta, timezone
-from unittest.mock import call, patch, ANY
+from unittest.mock import ANY, call, patch
 
 from freezegun import freeze_time
 from pay_api.models import Credit as CreditModel


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/15674
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
