### PR TITLE
28627 - EFT Refund use decision_by instead of updated_by

### DIFF
--- a/pay-api/migrations/versions/2025_05_28_b927265cf3a1_eft_refund_decision_by.py
+++ b/pay-api/migrations/versions/2025_05_28_b927265cf3a1_eft_refund_decision_by.py
@@ -1,0 +1,25 @@
+"""28627 - EFT Approver / Decliner update to use decision_by as updated_by can be overridden in other processes such
+as queue or job logic
+
+Revision ID: b927265cf3a1
+Revises: afccd441770e
+Create Date: 2025-05-28 14:01:48.597195
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'b927265cf3a1'
+down_revision = 'afccd441770e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('eft_refunds', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('decision_by', sa.String(length=50), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('eft_refunds', schema=None) as batch_op:
+        batch_op.drop_column('decision_by')

--- a/pay-api/src/pay_api/models/eft_refund.py
+++ b/pay-api/src/pay_api/models/eft_refund.py
@@ -47,6 +47,7 @@ class EFTRefund(Audit):
             "created_by",
             "created_name",
             "created_on",
+            "decision_by",
             "delivery_instructions",
             "disbursement_date",
             "disbursement_status_code",
@@ -75,6 +76,7 @@ class EFTRefund(Audit):
     comment = db.Column(db.String(), nullable=False)
     decline_reason = db.Column(db.String(), nullable=True)
     created_on = db.Column("created_on", db.DateTime, nullable=False, default=lambda: datetime.now(tz=timezone.utc))
+    decision_by = db.Column(db.String(50), nullable=True)
     disbursement_date = db.Column(
         "disbursement_date", db.DateTime, nullable=False, default=lambda: datetime.now(tz=timezone.utc)
     )

--- a/pay-api/src/pay_api/services/eft_refund.py
+++ b/pay-api/src/pay_api/services/eft_refund.py
@@ -202,6 +202,7 @@ class EFTRefund:
 
         refund.comment = data.comment or refund.comment
         refund.status = data.status or refund.status
+        refund.decision_by = user.user_name
 
         short_name = EFTShortnamesModel.find_by_id(refund.short_name_id)
         match data.status:

--- a/pay-api/tests/unit/api/test_eft_short_names.py
+++ b/pay-api/tests/unit/api/test_eft_short_names.py
@@ -1392,6 +1392,7 @@ def test_patch_shortname_refund(
             assert rv.json["status"] == EFTShortnameRefundStatus.APPROVED.value
             assert rv.json["comment"] == "Test comment"
             assert rv.json.get("declineReason") is None
+            assert rv.json.get("decisionBy") == user_name
             assert eft_history.transaction_type == EFTHistoricalTypes.SN_REFUND_APPROVED.value
             history = EFTShortnamesHistoryModel.find_by_eft_refund_id(refund.id)[0]
             assert history
@@ -1404,6 +1405,7 @@ def test_patch_shortname_refund(
             assert rv.json["status"] == EFTShortnameRefundStatus.DECLINED.value
             assert rv.json["comment"] == "Test comment"
             assert rv.json["declineReason"] == "Test reason"
+            assert rv.json.get("decisionBy") == user_name
             assert eft_history.transaction_type == EFTHistoricalTypes.SN_REFUND_DECLINED.value
             history = EFTShortnamesHistoryModel.find_by_eft_refund_id(refund.id)[0]
             assert history
@@ -1416,6 +1418,7 @@ def test_patch_shortname_refund(
             assert rv.json["status"] == EFTShortnameRefundStatus.APPROVED.value
             assert rv.json["comment"] == "test comment"
             assert rv.json["chequeStatus"] == ChequeRefundStatus.CHEQUE_UNDELIVERABLE.value
+            assert rv.json.get("decisionBy") == user_name
         case "invalid_cheque_status":
             assert rv.status_code == 400
             assert rv.json["type"] == Error.EFT_REFUND_CHEQUE_STATUS_INVALID_ACTION.name

--- a/pay-api/tests/unit/models/test_eft_refund.py
+++ b/pay-api/tests/unit/models/test_eft_refund.py
@@ -55,6 +55,7 @@ def test_eft_refund_defaults(session):
     assert eft_refund.status is None
     assert eft_refund.updated_by is None
     assert eft_refund.updated_name is None
+    assert eft_refund.decision_by is None
 
 
 def test_eft_refund_all_attributes(session):
@@ -71,6 +72,7 @@ def test_eft_refund_all_attributes(session):
     decline_reason = "Decline reason comment"
     updated_by = "user123"
     updated_name = "User Name"
+    decision_by = "user222"
 
     eft_refund = EFTRefundModel(
         short_name_id=short_name.id,
@@ -84,6 +86,7 @@ def test_eft_refund_all_attributes(session):
         created_by=created_by,
         updated_by=updated_by,
         updated_name=updated_name,
+        decision_by=decision_by,
     )
     eft_refund.save()
 
@@ -101,3 +104,4 @@ def test_eft_refund_all_attributes(session):
     assert eft_refund.created_by == created_by
     assert eft_refund.updated_by == updated_by
     assert eft_refund.updated_name == updated_name
+    assert eft_refund.decision_by == decision_by


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/19544

*Description of changes:*
- Change EFT Refund approve / decline to use decision_by


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
