### PR TITLE
28898 - EFT History updates

### DIFF
--- a/pay-api/src/pay_api/models/eft_short_names_historical.py
+++ b/pay-api/src/pay_api/models/eft_short_names_historical.py
@@ -102,6 +102,7 @@ class EFTShortnameHistorySchema:  # pylint: disable=too-few-public-methods
     short_name_balance: Decimal
     transaction_date: datetime
     transaction_type: str
+    created_on: datetime
     is_processing: bool
     is_reversible: bool
 
@@ -126,6 +127,7 @@ class EFTShortnameHistorySchema:  # pylint: disable=too-few-public-methods
             statement_number=getattr(row, "statement_number", None),
             transaction_date=getattr(row, "transaction_date", None),
             transaction_type=getattr(row, "transaction_type", None),
+            created_on=getattr(row, "created_on", None),
             is_processing=bool(getattr(row, "is_processing", False)),
             is_reversible=bool(getattr(row, "is_reversible", False)),
         )

--- a/pay-api/src/pay_api/services/eft_short_name_historical.py
+++ b/pay-api/src/pay_api/services/eft_short_name_historical.py
@@ -231,6 +231,7 @@ class EFTShortnameHistorical:
                 history_model.transaction_date,
                 history_model.transaction_type,
                 history_model.is_processing,
+                history_model.created_on,
                 PaymentAccountModel.auth_account_id,
                 cls._get_account_name(),
                 PaymentAccountModel.branch_name.label("account_branch"),
@@ -247,7 +248,7 @@ class EFTShortnameHistorical:
             .filter(history_model.hidden == false())
         )
 
-        query = query.order_by(history_model.transaction_date.desc(), history_model.id.desc())
+        query = query.order_by(history_model.created_on.desc(), history_model.id.desc())
 
         pagination = query.paginate(per_page=search_criteria.limit, page=search_criteria.page)
         history_list = unstructure_schema_items(EFTShortnameHistorySchema, pagination.items)

--- a/pay-api/src/pay_api/version.py
+++ b/pay-api/src/pay_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = "1.22.17"  # pylint: disable=invalid-name
+__version__ = "1.22.18"  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/28898

*Description of changes:*
- updates so UI can separate system date vs transaction date (could be a date from external source - e.g TDI17)
- fix default sorting to be driven off system create date for proper ordering when transaction_date may be backdated since it has an external source (e.g. TDI17 is processed today, but the deposit day is from 2-3 days ago)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
