### PR TITLE
27061 - Increase PAY test env memory

### DIFF
--- a/pay-api/devops/gcp/clouddeploy.yaml
+++ b/pay-api/devops/gcp/clouddeploy.yaml
@@ -45,6 +45,8 @@ serialPipeline:
       container-name: "pay-api-test"
       cloudsql-instances: "gtksf3-test:northamerica-northeast1:pay-db-test"
       service-account: "sa-api@gtksf3-test.iam.gserviceaccount.com"
+      resources-cpu: 4000m
+      resources-memory: 8Gi
  - targetId: gtksf3-sandbox
    profiles: [sandbox]
    strategy:

--- a/pay-api/devops/gcp/clouddeploy.yaml
+++ b/pay-api/devops/gcp/clouddeploy.yaml
@@ -46,7 +46,7 @@ serialPipeline:
       cloudsql-instances: "gtksf3-test:northamerica-northeast1:pay-db-test"
       service-account: "sa-api@gtksf3-test.iam.gserviceaccount.com"
       resources-cpu: 4000m
-      resources-memory: 8Gi
+      resources-memory: 2Gi
  - targetId: gtksf3-sandbox
    profiles: [sandbox]
    strategy:

--- a/pay-api/src/pay_api/services/payment_calculations.py
+++ b/pay-api/src/pay_api/services/payment_calculations.py
@@ -117,7 +117,6 @@ def build_grouped_invoice_context(invoices: List[dict], statement: dict, stateme
             has_staff_payment = False
 
         summary = calculate_invoice_summaries(items, method, statement)
-
         statement_header_text = StatementTitles["DEFAULT"].value
 
         if method == PaymentMethod.INTERNAL.value and has_staff_payment:


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/27061

*Description of changes:*

GCP is showing "memory limit of 1024 MiB exceeded with 1042 MiB used."
I tested locally with a larger statement and the memory usage was around 800 MB. It seems GCP handles memory control a bit differently, so I'm trying to set the test environment the same as prod to see if the error still occurs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
