### PR TITLE
fix: initialize default_payment_method variable in StatementContextDTO

### DIFF
--- a/pay-api/src/pay_api/utils/statement_dtos.py
+++ b/pay-api/src/pay_api/utils/statement_dtos.py
@@ -427,6 +427,7 @@ class StatementContextDTO(Serializable):
             payment_methods = [m.strip() for m in statement.payment_methods.split(",") if m.strip()]
 
         statement_header_text = None
+        default_payment_method = None
         if len(payment_methods) == 1:  # used for Statement that has no any invoices
             statement_header_text = StatementTitles[payment_methods[0]].value
             default_payment_method = payment_methods[0]


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/32043

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
