### PR TITLE
33222 - fix(ftp-poller): fix CrashLoopBackOff caused by bookworm glibc

### DIFF
--- a/jobs/ftp-poller/docker-entrypoint.sh
+++ b/jobs/ftp-poller/docker-entrypoint.sh
@@ -1,3 +1,13 @@
+#!/bin/bash
+
+# Fix for OpenShift random UID - bookworm's glibc is stricter about /etc/passwd lookups
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "pay:x:$(id -u):0:pay:/ftp-poller:/bin/bash" >> /etc/passwd
+    echo "Added UID $(id -u) to /etc/passwd"
+  fi
+fi
+
 function start_cron_jobs() {
   echo "Starting go-crond as a background task ..."
   CRON_CMD="go-crond -v --allow-unprivileged --include=cron/"


### PR DESCRIPTION
…asswd lookup

*Issue #:*
https://github.com/bcgov/entity/issues/33222

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
