### PR TITLE
33222 - Fix ftp-poller startup on OpenShift arbitrary UID with nss_wrapper

### DIFF
--- a/jobs/ftp-poller/Dockerfile
+++ b/jobs/ftp-poller/Dockerfile
@@ -69,6 +69,7 @@ RUN apt-get update \
     curl \
     gettext \
     git \
+    libnss-wrapper \
     libpq-dev \
     wait-for-it \
   && curl -sSL 'https://install.python-poetry.org' | python - \
@@ -78,7 +79,7 @@ RUN apt-get update \
   && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Copy only requirements, to cache them in docker layer
-COPY --chown=web:web ./poetry.lock ./pyproject.toml .
+COPY --chown=pay:pay ./poetry.lock ./pyproject.toml .
 
 # Project initialization:
 RUN --mount=type=cache,target="$POETRY_CACHE_DIR" \
@@ -94,11 +95,9 @@ COPY . .
 
 # Set ownership and permissions
 # Set scripts as executable (make files and python files do not have to be marked)
-# Make /etc/passwd writable for the root group so an entry can be created for an OpenShift assigned user account.
 RUN chown -R $user:root $HOME \
     && chmod -R ug+rw $HOME \
     && chmod ug+x $HOME/*.sh \
-    && chmod g+rw /etc/passwd \
     && chmod g-w $HOME/cron/crontab
 
 USER $user

--- a/jobs/ftp-poller/docker-entrypoint.sh
+++ b/jobs/ftp-poller/docker-entrypoint.sh
@@ -1,7 +1,39 @@
+function configure_nss_wrapper() {
+  local uid gid
+  uid="$(id -u)"
+  gid="$(id -g)"
+
+  # On OpenShift the container may run with a random UID that is not present in
+  # the image's passwd database. Some binaries, including go-crond, resolve the
+  # current user during startup and can fail if that lookup does not succeed.
+  if getent passwd "${uid}" >/dev/null 2>&1; then
+    return
+  fi
+
+  # nss_wrapper lets us provide a temporary passwd view for the current process
+  # without modifying the real /etc/passwd inside the container.
+  export NSS_WRAPPER_PASSWD
+  export NSS_WRAPPER_GROUP=/etc/group
+  NSS_WRAPPER_PASSWD="$(mktemp)"
+  cp /etc/passwd "${NSS_WRAPPER_PASSWD}"
+  echo "default:x:${uid}:${gid}:OpenShift User:${HOME}:/sbin/nologin" >> "${NSS_WRAPPER_PASSWD}"
+
+  export LD_PRELOAD
+  LD_PRELOAD="$(ldconfig -p | awk '/libnss_wrapper.so/ {print $NF; exit}')"
+
+  if [ -z "${LD_PRELOAD}" ]; then
+    echo "Unable to locate libnss_wrapper.so" >&2
+    exit 1
+  fi
+
+  echo "Configured nss_wrapper for arbitrary UID ${uid}"
+}
+
 function start_cron_jobs() {
   echo "Starting go-crond as a background task ..."
   CRON_CMD="go-crond -v --allow-unprivileged --include=cron/"
   exec ${CRON_CMD}
 }
 
+configure_nss_wrapper
 start_cron_jobs


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
Changes
- install libnss-wrapper
- configure a temporary passwd view in docker-entrypoint.sh when the current UID is missing
- avoid modifying the real /etc/passwd
- fix COPY --chown to use pay:pay

Why
After switching to python:3.12.2-bookworm, ftp-poller could fail to start on OpenShift when go-crond could not resolve the runtime UID. This keeps the bookworm base image and uses a safer runtime workaround than appending to /etc/passwd.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
