### PR TITLE
Fix ftp-poller startup on OpenShift arbitrary UID

### DIFF
--- a/jobs/ftp-poller/Dockerfile
+++ b/jobs/ftp-poller/Dockerfile
@@ -69,7 +69,6 @@ RUN apt-get update \
     curl \
     gettext \
     git \
-    libnss-wrapper \
     libpq-dev \
     wait-for-it \
   && curl -sSL 'https://install.python-poetry.org' | python - \
@@ -95,9 +94,12 @@ COPY . .
 
 # Set ownership and permissions
 # Set scripts as executable (make files and python files do not have to be marked)
+# Make /etc/passwd writable for the root group so the container can add a
+# runtime entry for an OpenShift-assigned arbitrary UID when needed.
 RUN chown -R $user:root $HOME \
     && chmod -R ug+rw $HOME \
     && chmod ug+x $HOME/*.sh \
+    && chmod g+rw /etc/passwd \
     && chmod g-w $HOME/cron/crontab
 
 USER $user

--- a/jobs/ftp-poller/docker-entrypoint.sh
+++ b/jobs/ftp-poller/docker-entrypoint.sh
@@ -1,7 +1,9 @@
-function configure_nss_wrapper() {
-  local uid gid
+function ensure_runtime_user() {
+  local uid gid runtime_user runtime_shell
   uid="$(id -u)"
   gid="$(id -g)"
+  runtime_user="app"
+  runtime_shell="/bin/sh"
 
   # On OpenShift the container may run with a random UID that is not present in
   # the image's passwd database. Some binaries, including go-crond, resolve the
@@ -10,23 +12,16 @@ function configure_nss_wrapper() {
     return
   fi
 
-  # nss_wrapper lets us provide a temporary passwd view for the current process
-  # without modifying the real /etc/passwd inside the container.
-  export NSS_WRAPPER_PASSWD
-  export NSS_WRAPPER_GROUP=/etc/group
-  NSS_WRAPPER_PASSWD="$(mktemp)"
-  cp /etc/passwd "${NSS_WRAPPER_PASSWD}"
-  echo "default:x:${uid}:${gid}:OpenShift User:${HOME}:/sbin/nologin" >> "${NSS_WRAPPER_PASSWD}"
-
-  export LD_PRELOAD
-  LD_PRELOAD="$(ldconfig -p | awk '/libnss_wrapper.so/ {print $NF; exit}')"
-
-  if [ -z "${LD_PRELOAD}" ]; then
-    echo "Unable to locate libnss_wrapper.so" >&2
+  # Add the smallest possible passwd entry for the current runtime identity.
+  # Use the actual uid/gid, avoid root-group membership, and provide a minimal
+  # shell path so user lookup succeeds before go-crond starts.
+  if [ ! -w /etc/passwd ]; then
+    echo "Unable to add runtime user entry: /etc/passwd is not writable" >&2
     exit 1
   fi
 
-  echo "Configured nss_wrapper for arbitrary UID ${uid}"
+  echo "${runtime_user}:x:${uid}:${gid}:${runtime_user}:${HOME}:${runtime_shell}" >> /etc/passwd
+  echo "Added runtime passwd entry for UID ${uid}"
 }
 
 function start_cron_jobs() {
@@ -35,5 +30,5 @@ function start_cron_jobs() {
   exec ${CRON_CMD}
 }
 
-configure_nss_wrapper
+ensure_runtime_user
 start_cron_jobs


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
Use a minimal runtime passwd-entry workaround for OpenShift-assigned arbitrary UIDs before starting go-crond. This only adds an entry when the current UID is missing, uses the actual runtime uid:gid, and avoids root-group membership and /bin/bash.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
