### PR TITLE
Build go-crond from source for ftp-poller on bookworm

### DIFF
--- a/jobs/ftp-poller/Dockerfile
+++ b/jobs/ftp-poller/Dockerfile
@@ -1,3 +1,25 @@
+ARG SOURCE_REPO=BCDevOps
+ARG GOCROND_VERSION=0.6.2
+ARG VCS_REF="missing"
+ARG BUILD_DATE="missing"
+
+FROM golang:1.22-bookworm AS go-crond-builder
+
+ARG SOURCE_REPO
+ARG GOCROND_VERSION
+
+WORKDIR /tmp
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build go-crond from source with cgo disabled so os/user uses the pure-Go
+# lookup path instead of the glibc/cgo path that was crashing on bookworm.
+RUN git clone --branch "${GOCROND_VERSION}" --depth 1 "https://github.com/${SOURCE_REPO}/go-crond.git" \
+    && cd go-crond \
+    && CGO_ENABLED=0 go build -tags osusergo,netgo -o /usr/local/bin/go-crond .
+
 FROM python:3.12.2-bookworm
 # ========================================================================================================
 # Install go-crond (from https://github.com/BCDevOps/go-crond)
@@ -8,10 +30,10 @@ FROM python:3.12.2-bookworm
 # - https://blog.danman.eu/cron-jobs-in-openshift/
 #
 # --------------------------------------------------------------------------------------------------------
-ARG SOURCE_REPO=BCDevOps
-ARG GOCROND_VERSION=0.6.2
-ARG VCS_REF="missing"
-ARG BUILD_DATE="missing"
+ARG SOURCE_REPO
+ARG GOCROND_VERSION
+ARG VCS_REF
+ARG BUILD_DATE
 
 ENV VCS_REF=${VCS_REF}
 ENV BUILD_DATE=${BUILD_DATE}
@@ -19,7 +41,7 @@ ENV BUILD_DATE=${BUILD_DATE}
 LABEL org.label-schema.vcs-ref=${VCS_REF} \
     org.label-schema.build-date=${BUILD_DATE}
 
-RUN curl https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux -s -L -o /usr/local/bin/go-crond
+COPY --from=go-crond-builder /usr/local/bin/go-crond /usr/local/bin/go-crond
 RUN chmod ug+x /usr/local/bin/go-crond
 # ========================================================================================================
 
@@ -94,8 +116,7 @@ COPY . .
 
 # Set ownership and permissions
 # Set scripts as executable (make files and python files do not have to be marked)
-# Make /etc/passwd writable for the root group so the container can add a
-# runtime entry for an OpenShift-assigned arbitrary UID when needed.
+# Make /etc/passwd writable for the root group so an entry can be created for an OpenShift assigned user account.
 RUN chown -R $user:root $HOME \
     && chmod -R ug+rw $HOME \
     && chmod ug+x $HOME/*.sh \

--- a/jobs/ftp-poller/docker-entrypoint.sh
+++ b/jobs/ftp-poller/docker-entrypoint.sh
@@ -31,4 +31,12 @@ function start_cron_jobs() {
 }
 
 ensure_runtime_user
+
+# Temporary debug output to confirm the runtime UID is resolvable before
+# go-crond starts. Remove once the startup issue is understood.
+id
+getent passwd "$(id -u)" || true
+grep "$(id -u)" /etc/passwd || true
+tail -n 5 /etc/passwd
+
 start_cron_jobs

--- a/jobs/ftp-poller/docker-entrypoint.sh
+++ b/jobs/ftp-poller/docker-entrypoint.sh
@@ -31,5 +31,4 @@ function start_cron_jobs() {
 }
 
 ensure_runtime_user
-
 start_cron_jobs

--- a/jobs/ftp-poller/docker-entrypoint.sh
+++ b/jobs/ftp-poller/docker-entrypoint.sh
@@ -32,11 +32,4 @@ function start_cron_jobs() {
 
 ensure_runtime_user
 
-# Temporary debug output to confirm the runtime UID is resolvable before
-# go-crond starts. Remove once the startup issue is understood.
-id
-getent passwd "$(id -u)" || true
-grep "$(id -u)" /etc/passwd || true
-tail -n 5 /etc/passwd
-
 start_cron_jobs


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
Replaces the prebuilt go-crond release binary with a source-built CGO_ENABLED=0 version in jobs/ftp-poller. This keeps the bookworm base image, avoids the crashing os/user cgo lookup path, and retains the minimal OpenShift arbitrary-UID passwd workaround for runtime user resolution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
