### PR TITLE
33213 - fix(pay-queue): render CGI reconciliation error email messages correctly

### DIFF
--- a/pay-queue/src/pay_queue/services/cgi_reconciliations.py
+++ b/pay-queue/src/pay_queue/services/cgi_reconciliations.py
@@ -93,14 +93,20 @@ def _update_feedback(msg: dict[str, any], cloud_event):  # pylint:disable=too-ma
     has_errors = _process_ap_feedback(group_batches["AP"]) or has_errors
 
     if has_errors and not APP_CONFIG.DISABLE_EJV_ERROR_EMAIL:
+        error_messages = [
+            {
+                "error": "The GL disbursement failed for the electronic journal voucher batch. "
+                "It maybe necessary to contact the ministry to get the correct GL and update in the "
+                "BC Registries application. Unless this is an error is unrelated to the GL correctness. "
+                "The error report is attached with further details.",
+                "row": None,
+            },
+        ]
         email_service_params = EmailParams(
             subject="Payment Reconciliation Failure - GL disbursement failure for EJV",
             file_name=file_name,
             google_bucket_name=f"{current_app.config.get('GOOGLE_BUCKET_NAME')}/{bucket_folder_name}",
-            error_messages="The GL disbursement failed for the electronic journal voucher batch. "
-            "It maybe necessary to contact the ministry to get the correct GL and update in the "
-            "BC Registries application. Unless this is an error is unrelated to the GL correctness."
-            "The error report is attached with further details.",
+            error_messages=error_messages,
             ce=cloud_event,
             table_name=EjvFileModel.__tablename__,
         )

--- a/pay-queue/tests/integration/test_cgi_reconciliations.py
+++ b/pay-queue/tests/integration/test_cgi_reconciliations.py
@@ -2184,7 +2184,11 @@ def test_ejv_batch_failure_sends_error_email(session, app, client, mocker):
     assert email_params.file_name == feedback_file_name
     assert email_params.google_bucket_name == f"{app.config.get('GOOGLE_BUCKET_NAME')}/test-folder"
     assert email_params.table_name == EjvFileModel.__tablename__
-    assert "The GL disbursement failed for the electronic journal voucher batch" in email_params.error_messages
+    assert len(email_params.error_messages) == 1
+    assert (
+        "The GL disbursement failed for the electronic journal voucher batch"
+        in email_params.error_messages[0]["error"]
+    )
 
     ejv_file = EjvFileModel.find_by_id(ejv_file_id)
     assert ejv_file.disbursement_status_code == DisbursementStatus.ERRORED.value

--- a/pay-queue/tests/integration/test_cgi_reconciliations.py
+++ b/pay-queue/tests/integration/test_cgi_reconciliations.py
@@ -2186,8 +2186,7 @@ def test_ejv_batch_failure_sends_error_email(session, app, client, mocker):
     assert email_params.table_name == EjvFileModel.__tablename__
     assert len(email_params.error_messages) == 1
     assert (
-        "The GL disbursement failed for the electronic journal voucher batch"
-        in email_params.error_messages[0]["error"]
+        "The GL disbursement failed for the electronic journal voucher batch" in email_params.error_messages[0]["error"]
     )
 
     ejv_file = EjvFileModel.find_by_id(ejv_file_id)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/33213

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
