### PR TITLE
fix: fall back to ADC when GOOGLE_STORAGE_SA is not set in GoogleBucketService

### DIFF
--- a/pay-api/src/pay_api/services/google_bucket_service.py
+++ b/pay-api/src/pay_api/services/google_bucket_service.py
@@ -31,10 +31,12 @@ class GoogleBucketService:
     def get_client() -> storage.Client:
         """Get a Google cloud storage client."""
         current_app.logger.info("Initializing Google Storage client.")
-        json_text = base64.b64decode(current_app.config.get("GOOGLE_STORAGE_SA")).decode("utf-8")
-        auth_json = json.loads(json_text, strict=False)
-        client = storage.Client.from_service_account_info(auth_json)
-        return client
+        google_storage_sa = current_app.config.get("GOOGLE_STORAGE_SA")
+        if google_storage_sa:
+            json_text = base64.b64decode(google_storage_sa).decode("utf-8")
+            auth_json = json.loads(json_text, strict=False)
+            return storage.Client.from_service_account_info(auth_json)
+        return storage.Client()
 
     @staticmethod
     def get_bucket(client: storage.Client, bucket_name: str) -> storage.Bucket:

--- a/pay-api/tests/unit/services/test_google_bucket_service.py
+++ b/pay-api/tests/unit/services/test_google_bucket_service.py
@@ -65,7 +65,7 @@ def temp_test_files() -> Iterator[list[str]]:
 
 
 def test_get_client(session, app) -> None:
-    """Test getting storage client."""
+    """Test getting storage client using explicit service account credentials."""
     service_account_info = {}
 
     encoded_credentials = base64.b64encode(json.dumps(service_account_info).encode()).decode()
@@ -78,6 +78,20 @@ def test_get_client(session, app) -> None:
         client = GoogleBucketService.get_client()
 
         mock_client_method.assert_called_once_with(service_account_info)
+        assert client == mock_client_instance
+
+
+def test_get_client_default_credentials(session, app) -> None:
+    """Test getting storage client via ADC when GOOGLE_STORAGE_SA is not set."""
+    app.config["GOOGLE_STORAGE_SA"] = None
+
+    with patch("pay_api.services.google_bucket_service.storage.Client") as mock_client_class:
+        mock_client_instance = MagicMock()
+        mock_client_class.return_value = mock_client_instance
+
+        client = GoogleBucketService.get_client()
+
+        mock_client_class.assert_called_once_with()
         assert client == mock_client_instance
 
 


### PR DESCRIPTION
If GOOGLE_STORAGE_SA is absent (e.g. revoked key removed from secret), get_client() now calls storage.Client() which uses Application Default Credentials (WIF via GOOGLE_APPLICATION_CREDENTIALS) instead of crashing with a TypeError or Invalid JWT Signature error.

*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
