### PR TITLE
fix: read GOOGLE_STORAGE_SA from os.environ and use google.auth.default() fallback

### DIFF
--- a/pay-api/src/pay_api/services/google_bucket_service.py
+++ b/pay-api/src/pay_api/services/google_bucket_service.py
@@ -18,6 +18,7 @@ import json
 import os
 import tempfile
 
+import google.auth
 from attrs import define
 from flask import current_app
 from google.cloud import storage
@@ -31,12 +32,13 @@ class GoogleBucketService:
     def get_client() -> storage.Client:
         """Get a Google cloud storage client."""
         current_app.logger.info("Initializing Google Storage client.")
-        google_storage_sa = current_app.config.get("GOOGLE_STORAGE_SA")
+        google_storage_sa = os.environ.get("GOOGLE_STORAGE_SA") or current_app.config.get("GOOGLE_STORAGE_SA")
         if google_storage_sa:
             json_text = base64.b64decode(google_storage_sa).decode("utf-8")
             auth_json = json.loads(json_text, strict=False)
             return storage.Client.from_service_account_info(auth_json)
-        return storage.Client()
+        credentials, project = google.auth.default()
+        return storage.Client(credentials=credentials, project=project)
 
     @staticmethod
     def get_bucket(client: storage.Client, bucket_name: str) -> storage.Bucket:

--- a/pay-api/tests/unit/services/test_google_bucket_service.py
+++ b/pay-api/tests/unit/services/test_google_bucket_service.py
@@ -84,14 +84,17 @@ def test_get_client(session, app) -> None:
 def test_get_client_default_credentials(session, app) -> None:
     """Test getting storage client via ADC when GOOGLE_STORAGE_SA is not set."""
     app.config["GOOGLE_STORAGE_SA"] = None
+    mock_creds = MagicMock()
 
-    with patch("pay_api.services.google_bucket_service.storage.Client") as mock_client_class:
+    with patch("pay_api.services.google_bucket_service.google.auth.default", return_value=(mock_creds, "test-project")) as mock_auth, \
+         patch("pay_api.services.google_bucket_service.storage.Client") as mock_client_class:
         mock_client_instance = MagicMock()
         mock_client_class.return_value = mock_client_instance
 
         client = GoogleBucketService.get_client()
 
-        mock_client_class.assert_called_once_with()
+        mock_auth.assert_called_once()
+        mock_client_class.assert_called_once_with(credentials=mock_creds, project="test-project")
         assert client == mock_client_instance
 
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:* Travis removed GOOGLE_STORAGE_SA from config.py so current_app.config.get() always returns None. Read from os.environ first so the OCP secret value is picked up. Use google.auth.default() for the ADC/WIF fallback to supply both credentials and project, avoiding the storage client failing on OpenShift.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
