### PR TITLE
33384 - fix transaction 500 for NRO OB without invoice reference

### DIFF
--- a/pay-api/src/pay_api/services/payment_transaction.py
+++ b/pay-api/src/pay_api/services/payment_transaction.py
@@ -35,7 +35,6 @@ from pay_api.services.invoice import Invoice
 from pay_api.services.invoice_reference import InvoiceReference
 from pay_api.services.payment_account import PaymentAccount
 from pay_api.services.receipt import Receipt
-from pay_api.utils import user_context
 from pay_api.utils.dataclasses import PaymentToken
 from pay_api.utils.enums import (
     CorpType,
@@ -47,6 +46,7 @@ from pay_api.utils.enums import (
     TransactionStatus,
 )
 from pay_api.utils.errors import Error
+from pay_api.utils.user_context import _get_token
 from pay_api.utils.util import get_topic_for_corp_type, is_valid_redirect_url
 
 from .payment import Payment
@@ -313,7 +313,7 @@ class PaymentTransaction:  # pylint: disable=too-many-instance-attributes, too-m
         )
         # NRO OB has no reference until signed-in (click "Pay Now", PATCH); unauthenticated POST needs login, not 500.
         if (
-            not user_context._get_token()
+            not _get_token()
             and invoice.payment_method_code == PaymentMethod.ONLINE_BANKING.value
             and invoice.corp_type_code == CorpType.NRO.value
         ):

--- a/pay-api/src/pay_api/services/payment_transaction.py
+++ b/pay-api/src/pay_api/services/payment_transaction.py
@@ -35,6 +35,7 @@ from pay_api.services.invoice import Invoice
 from pay_api.services.invoice_reference import InvoiceReference
 from pay_api.services.payment_account import PaymentAccount
 from pay_api.services.receipt import Receipt
+from pay_api.utils import user_context
 from pay_api.utils.dataclasses import PaymentToken
 from pay_api.utils.enums import (
     CorpType,
@@ -46,7 +47,6 @@ from pay_api.utils.enums import (
     TransactionStatus,
 )
 from pay_api.utils.errors import Error
-from pay_api.utils import user_context
 from pay_api.utils.util import get_topic_for_corp_type, is_valid_redirect_url
 
 from .payment import Payment

--- a/pay-api/src/pay_api/services/payment_transaction.py
+++ b/pay-api/src/pay_api/services/payment_transaction.py
@@ -37,6 +37,7 @@ from pay_api.services.payment_account import PaymentAccount
 from pay_api.services.receipt import Receipt
 from pay_api.utils.dataclasses import PaymentToken
 from pay_api.utils.enums import (
+    CorpType,
     InvoiceReferenceStatus,
     InvoiceStatus,
     PaymentMethod,
@@ -45,6 +46,7 @@ from pay_api.utils.enums import (
     TransactionStatus,
 )
 from pay_api.utils.errors import Error
+from pay_api.utils import user_context
 from pay_api.utils.util import get_topic_for_corp_type, is_valid_redirect_url
 
 from .payment import Payment
@@ -236,6 +238,7 @@ class PaymentTransaction:  # pylint: disable=too-many-instance-attributes, too-m
         if not payment:
             # Transaction is against payment, so create a payment if not present.
             invoice_reference = InvoiceReference.find_active_reference_by_invoice_id(invoice.id)
+            PaymentTransaction._validate_invoice_reference_for_transaction(invoice, invoice_reference)
 
             # Create a payment record
             payment = Payment.create(
@@ -298,6 +301,24 @@ class PaymentTransaction:  # pylint: disable=too-many-instance-attributes, too-m
         transaction_dao = transaction.save()
         transaction = PaymentTransaction.__wrap_dao(transaction_dao)
         return transaction
+
+    @staticmethod
+    def _validate_invoice_reference_for_transaction(invoice: Invoice, invoice_reference: InvoiceReference | None):
+        """Ensure invoice reference exists before creating a payment for a transaction."""
+        if invoice_reference:
+            return
+        current_app.logger.warning(
+            f"No active invoice reference for invoice {invoice.id} "
+            f"({invoice.payment_method_code}, {invoice.corp_type_code}, {invoice.invoice_status_code})"
+        )
+        # NRO OB has no reference until signed-in (click "Pay Now", PATCH); unauthenticated POST needs login, not 500.
+        if (
+            not user_context._get_token()
+            and invoice.payment_method_code == PaymentMethod.ONLINE_BANKING.value
+            and invoice.corp_type_code == CorpType.NRO.value
+        ):
+            raise BusinessException(Error.PAYMENT_REQUIRES_LOGIN)
+        raise BusinessException(Error.INVOICE_PAYMENT_NOT_READY)
 
     @staticmethod
     def _validate_redirect_url_and_throw_error(payment_method: str, return_url: str):

--- a/pay-api/src/pay_api/utils/errors.py
+++ b/pay-api/src/pay_api/utils/errors.py
@@ -74,9 +74,7 @@ class Error(Enum):
     INVOICE_PAYMENT_NOT_READY = (
         "INVOICE_PAYMENT_NOT_READY",
         HTTPStatus.BAD_REQUEST,
-        (
-            "Payment cannot be started for this invoice, since invoice reference is not yet available."
-        ),
+        ("Payment cannot be started for this invoice, since invoice reference is not yet available."),
     )
     PATCH_INVALID_ACTION = "PATCH_INVALID_ACTION", HTTPStatus.BAD_REQUEST
 

--- a/pay-api/src/pay_api/utils/errors.py
+++ b/pay-api/src/pay_api/utils/errors.py
@@ -66,6 +66,18 @@ class Error(Enum):
 
     SERVICE_UNAVAILABLE = "SERVICE_UNAVAILABLE", HTTPStatus.SERVICE_UNAVAILABLE
     INVALID_REQUEST = "INVALID_REQUEST", HTTPStatus.BAD_REQUEST, "Invalid Request"
+    PAYMENT_REQUIRES_LOGIN = (
+        "PAYMENT_REQUIRES_LOGIN",
+        HTTPStatus.UNAUTHORIZED,
+        "Sign in is required to pay this invoice with a credit card.",
+    )
+    INVOICE_PAYMENT_NOT_READY = (
+        "INVOICE_PAYMENT_NOT_READY",
+        HTTPStatus.BAD_REQUEST,
+        (
+            "Payment cannot be started for this invoice, since invoice reference is not yet available."
+        ),
+    )
     PATCH_INVALID_ACTION = "PATCH_INVALID_ACTION", HTTPStatus.BAD_REQUEST
 
     PAYMENT_SEARCH_TOO_MANY_RECORDS = (

--- a/pay-api/tests/unit/services/test_payment_transaction.py
+++ b/pay-api/tests/unit/services/test_payment_transaction.py
@@ -155,6 +155,42 @@ def test_transaction_create_from_invalid_payment(session):
     assert excinfo.value.code == Error.INVALID_INVOICE_ID.name
 
 
+def test_create_transaction_for_invoice_ob_nro_without_reference_requires_login(session):
+    """Assert unauthenticated OB NRO invoice returns PAYMENT_REQUIRES_LOGIN."""
+    payment_account = factory_payment_account()
+    payment_account.save()
+    invoice = factory_invoice(
+        payment_account,
+        payment_method_code=PaymentMethod.ONLINE_BANKING.value,
+        corp_type_code="NRO",
+    )
+    invoice.save()
+
+    with pytest.raises(BusinessException) as excinfo:
+        PaymentTransactionService.create_transaction_for_invoice(invoice.id, get_paybc_transaction_request())
+    assert excinfo.value.code == Error.PAYMENT_REQUIRES_LOGIN.name
+
+
+def test_create_transaction_for_invoice_ob_nro_without_reference_not_ready_when_authenticated(
+    session, monkeypatch
+):
+    """Assert authenticated OB NRO invoice without reference returns INVOICE_PAYMENT_NOT_READY."""
+    payment_account = factory_payment_account()
+    payment_account.save()
+    invoice = factory_invoice(
+        payment_account,
+        payment_method_code=PaymentMethod.ONLINE_BANKING.value,
+        corp_type_code="NRO",
+    )
+    invoice.save()
+
+    monkeypatch.setattr("pay_api.utils.user_context._get_token", lambda: "test-token")
+
+    with pytest.raises(BusinessException) as excinfo:
+        PaymentTransactionService.create_transaction_for_invoice(invoice.id, get_paybc_transaction_request())
+    assert excinfo.value.code == Error.INVOICE_PAYMENT_NOT_READY.name
+
+
 @skip_in_pod
 def test_transaction_update(session, public_user_mock):
     """Assert that the payment is saved to the table."""

--- a/pay-api/tests/unit/services/test_payment_transaction.py
+++ b/pay-api/tests/unit/services/test_payment_transaction.py
@@ -171,9 +171,7 @@ def test_create_transaction_for_invoice_ob_nro_without_reference_requires_login(
     assert excinfo.value.code == Error.PAYMENT_REQUIRES_LOGIN.name
 
 
-def test_create_transaction_for_invoice_ob_nro_without_reference_not_ready_when_authenticated(
-    session, monkeypatch
-):
+def test_create_transaction_for_invoice_ob_nro_without_reference_not_ready_when_authenticated(session, monkeypatch):
     """Assert authenticated OB NRO invoice without reference returns INVOICE_PAYMENT_NOT_READY."""
     payment_account = factory_payment_account()
     payment_account.save()

--- a/pay-api/tests/unit/services/test_payment_transaction.py
+++ b/pay-api/tests/unit/services/test_payment_transaction.py
@@ -182,7 +182,7 @@ def test_create_transaction_for_invoice_ob_nro_without_reference_not_ready_when_
     )
     invoice.save()
 
-    monkeypatch.setattr("pay_api.utils.user_context._get_token", lambda: "test-token")
+    monkeypatch.setattr("pay_api.services.payment_transaction._get_token", lambda: "test-token")
 
     with pytest.raises(BusinessException) as excinfo:
         PaymentTransactionService.create_transaction_for_invoice(invoice.id, get_paybc_transaction_request())


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/33384

*Description of changes:*
invoice reference not existing because the flow of pay with credit card for NRO with online banking account. It created invoice reference in a patch request after user click "Pay", but it need login.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
