### PR TITLE
33375 - cfs token refresh / caching

### DIFF
--- a/pay-api/src/pay_api/config.py
+++ b/pay-api/src/pay_api/config.py
@@ -137,6 +137,8 @@ class _Config:  # pylint: disable=too-few-public-methods
     CFS_INVOICE_PREFIX = os.getenv("CFS_INVOICE_PREFIX", "REG")
     CFS_RECEIPT_PREFIX = os.getenv("CFS_RECEIPT_PREFIX", "RCPT")
     CFS_PARTY_PREFIX = os.getenv("CFS_PARTY_PREFIX", "BCR-")
+    # Intentionally set lower to facilitate faster recovery from CFS outages / issues
+    CFS_TOKEN_CACHE_TIMEOUT = int(os.getenv("CFS_TOKEN_CACHE_TIMEOUT", "300"))
     PAY_CONNECTOR_AUTH = os.getenv("PAY_CONNECTOR_AUTH", "")
 
     # EFT Config

--- a/pay-api/src/pay_api/services/cfs_service.py
+++ b/pay-api/src/pay_api/services/cfs_service.py
@@ -15,13 +15,14 @@
 
 import base64
 import re
+import time
 from collections import defaultdict
 from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Any
 
 from flask import current_app
-from requests import HTTPError
+from requests import HTTPError, Response
 
 from pay_api.exceptions import ServiceUnavailableException
 from pay_api.models import CfsAccount as CfsAccountModel
@@ -70,6 +71,9 @@ class ProcessingContext:
     lines_map: dict
     index: int
     negate: bool
+
+
+_token_cache: dict[str, tuple[Response, float]] = {}
 
 
 class CFSService(OAuthService):
@@ -467,6 +471,14 @@ class CFSService(OAuthService):
     def get_token(payment_system=PaymentSystem.PAYBC):
         """Generate oauth token from PayBC/FAS which will be used for all communication."""
         current_app.logger.debug("<Getting token")
+        cache_key = f"cfs_token_{payment_system.value}"
+        now = time.time()
+        if cache_key in _token_cache:
+            cached_response, expires_at = _token_cache[cache_key]
+            if now < expires_at:
+                current_app.logger.debug(">Getting token (cached)")
+                return cached_response
+
         token_url = current_app.config.get("CFS_BASE_URL", None) + "/oauth/token"
         match payment_system:
             case PaymentSystem.PAYBC:
@@ -487,6 +499,11 @@ class CFSService(OAuthService):
             data,
             additional_headers={"Pay-Connector": current_app.config.get("PAY_CONNECTOR_AUTH")},
         )
+        if token_response.json().get("access_token"):
+            timeout = current_app.config.get("CFS_TOKEN_CACHE_TIMEOUT")
+            _token_cache[cache_key] = (token_response, now + timeout)
+        else:
+            _token_cache.pop(cache_key, None)
         current_app.logger.debug(">Getting token")
         return token_response
 

--- a/pay-api/src/pay_api/services/oauth_service.py
+++ b/pay-api/src/pay_api/services/oauth_service.py
@@ -101,12 +101,12 @@ class OAuthService:
                 return response.iter_content()
 
         except (ReqConnectionError, ConnectTimeout) as exc:
-            current_app.logger.error("---Error on POST---")
+            current_app.logger.error(f"---Error on POST--- {endpoint}")
             current_app.logger.error(exc)
             raise ServiceUnavailableException(exc) from exc
         except HTTPError as exc:
             current_app.logger.error(
-                f"HTTPError on POST with status code {exc.response.status_code if exc.response is not None else ''}"
+                f"HTTPError on POST with status code {exc.response.status_code if exc.response is not None else ''} {endpoint}"
             )
             if exc.response and exc.response.status_code >= 500:
                 raise ServiceUnavailableException(exc) from exc
@@ -176,13 +176,13 @@ class OAuthService:
             )
             response.raise_for_status()
         except (ReqConnectionError, ConnectTimeout) as exc:
-            current_app.logger.error("---Error on GET---")
+            current_app.logger.error(f"---Error on GET--- {endpoint}")
             current_app.logger.error(exc)
             raise ServiceUnavailableException(exc) from exc
         except HTTPError as exc:
             if exc.response is None or exc.response.status_code != 404:
                 current_app.logger.error(
-                    f"HTTPError on GET with status code {exc.response.status_code if exc.response is not None else ''}"
+                    f"HTTPError on GET with status code {exc.response.status_code if exc.response is not None else ''} {endpoint}"
                 )
             if exc.response is not None:
                 if exc.response.status_code >= 500:

--- a/pay-api/src/pay_api/version.py
+++ b/pay-api/src/pay_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = "1.25.0"  # pylint: disable=invalid-name
+__version__ = "1.25.1"  # pylint: disable=invalid-name

--- a/pay-api/tests/conftest.py
+++ b/pay-api/tests/conftest.py
@@ -24,6 +24,7 @@ from sqlalchemy import create_engine, event, text
 from pay_api import create_app, setup_jwt_manager
 from pay_api import jwt as _jwt
 from pay_api.models import db as _db
+from pay_api.services.cfs_service import _token_cache as _cfs_token_cache
 from pay_api.services.code import Code as CodeService
 from pay_api.utils.cache import cache
 
@@ -150,6 +151,14 @@ def setup_code_service(session, app):
     with app.app_context():
         cache.clear()
         CodeService.build_all_codes_cache()
+
+
+@pytest.fixture(autouse=True)
+def clear_cfs_token_cache():
+    """Reset the module-level CFS token cache before and after each test."""
+    _cfs_token_cache.clear()
+    yield
+    _cfs_token_cache.clear()
 
 
 @pytest.fixture()

--- a/pay-api/tests/unit/services/test_cfs_service.py
+++ b/pay-api/tests/unit/services/test_cfs_service.py
@@ -301,8 +301,10 @@ def test_get_token_caches_within_timeout(session, app):
     token = secrets.token_hex(32)
     timeout = app.config["CFS_TOKEN_CACHE_TIMEOUT"]
 
-    with patch("pay_api.services.cfs_service.time.time") as mock_time, \
-         patch("pay_api.services.oauth_service.requests.post", return_value=_mock_token_response(token)) as mock_post:
+    with (
+        patch("pay_api.services.cfs_service.time.time") as mock_time,
+        patch("pay_api.services.oauth_service.requests.post", return_value=_mock_token_response(token)) as mock_post,
+    ):
         mock_time.return_value = 1000.0
         first = CFSService.get_token()
 
@@ -322,8 +324,10 @@ def test_get_token_refetches_after_timeout(session, app):
     start = 1000.0
     timeout = app.config["CFS_TOKEN_CACHE_TIMEOUT"]
 
-    with patch("pay_api.services.cfs_service.time.time") as mock_time, \
-         patch("pay_api.services.oauth_service.requests.post") as mock_post:
+    with (
+        patch("pay_api.services.cfs_service.time.time") as mock_time,
+        patch("pay_api.services.oauth_service.requests.post") as mock_post,
+    ):
         mock_post.side_effect = [_mock_token_response(first_token), _mock_token_response(second_token)]
 
         mock_time.return_value = start
@@ -343,8 +347,10 @@ def test_get_token_paybc_and_fas_cached_separately(session, app):
     paybc_token = secrets.token_hex(32)
     fas_token = secrets.token_hex(32)
 
-    with patch.dict(app.config, {"CFS_FAS_CLIENT_ID": "TEST_FAS", "CFS_FAS_CLIENT_SECRET": "TEST_FAS"}), \
-         patch("pay_api.services.oauth_service.requests.post") as mock_post:
+    with (
+        patch.dict(app.config, {"CFS_FAS_CLIENT_ID": "TEST_FAS", "CFS_FAS_CLIENT_SECRET": "TEST_FAS"}),
+        patch("pay_api.services.oauth_service.requests.post") as mock_post,
+    ):
         mock_post.side_effect = [_mock_token_response(paybc_token), _mock_token_response(fas_token)]
 
         paybc = CFSService.get_token(PaymentSystem.PAYBC)
@@ -369,5 +375,6 @@ def test_get_token_clears_cache_on_bad_response(session):
         result = CFSService.get_token()
 
     from pay_api.services.cfs_service import _token_cache
+
     assert result is bad_response
     assert "cfs_token_PAYBC" not in _token_cache

--- a/pay-api/tests/unit/services/test_cfs_service.py
+++ b/pay-api/tests/unit/services/test_cfs_service.py
@@ -17,8 +17,9 @@
 Test-Suite to ensure that the CFS Service layer is working as expected.
 """
 
+import secrets
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from requests import ConnectTimeout
 
@@ -26,6 +27,7 @@ from pay_api.models import DistributionCode as DistributionCodeModel
 from pay_api.models import PaymentLineItem as PaymentLineItemModel
 from pay_api.services.cfs_service import CFSService
 from pay_api.utils.constants import TAX_CLASSIFICATION_GST
+from pay_api.utils.enums import PaymentSystem
 from tests.utilities.base_test import factory_distribution_code
 
 cfs_service = CFSService()
@@ -286,3 +288,86 @@ def test_build_lines_with_gst_fees(session):
     _verify_line_structure(statutory_gst_line, Decimal("5.00"))
     _verify_line_structure(service_gst_line, Decimal("0.50"))
     _verify_line_structure(combined_gst_line, Decimal("3.75"))  # 2.50 + 1.25 from combined GST test
+
+
+def _mock_token_response(access_token: str) -> MagicMock:
+    mock = MagicMock()
+    mock.json.return_value = {"access_token": access_token}
+    return mock
+
+
+def test_get_token_caches_within_timeout(session, app):
+    """Token is fetched once and the same object is returned on a second call before timeout."""
+    token = secrets.token_hex(32)
+    timeout = app.config["CFS_TOKEN_CACHE_TIMEOUT"]
+
+    with patch("pay_api.services.cfs_service.time.time") as mock_time, \
+         patch("pay_api.services.oauth_service.requests.post", return_value=_mock_token_response(token)) as mock_post:
+        mock_time.return_value = 1000.0
+        first = CFSService.get_token()
+
+        mock_time.return_value = 1000.0 + timeout - 1
+        second = CFSService.get_token()
+
+    assert mock_post.call_count == 1
+    assert first.json().get("access_token") == token
+    assert second is first
+
+
+def test_get_token_refetches_after_timeout(session, app):
+    """A new token is fetched after the cache entry expires."""
+    first_token = secrets.token_hex(32)
+    second_token = secrets.token_hex(32)
+
+    start = 1000.0
+    timeout = app.config["CFS_TOKEN_CACHE_TIMEOUT"]
+
+    with patch("pay_api.services.cfs_service.time.time") as mock_time, \
+         patch("pay_api.services.oauth_service.requests.post") as mock_post:
+        mock_post.side_effect = [_mock_token_response(first_token), _mock_token_response(second_token)]
+
+        mock_time.return_value = start
+        first = CFSService.get_token()
+
+        mock_time.return_value = start + timeout + 1
+        second = CFSService.get_token()
+
+    assert mock_post.call_count == 2
+    assert first.json().get("access_token") == first_token
+    assert second.json().get("access_token") == second_token
+    assert second is not first
+
+
+def test_get_token_paybc_and_fas_cached_separately(session, app):
+    """PAYBC and FAS tokens are stored under separate cache keys."""
+    paybc_token = secrets.token_hex(32)
+    fas_token = secrets.token_hex(32)
+
+    with patch.dict(app.config, {"CFS_FAS_CLIENT_ID": "TEST_FAS", "CFS_FAS_CLIENT_SECRET": "TEST_FAS"}), \
+         patch("pay_api.services.oauth_service.requests.post") as mock_post:
+        mock_post.side_effect = [_mock_token_response(paybc_token), _mock_token_response(fas_token)]
+
+        paybc = CFSService.get_token(PaymentSystem.PAYBC)
+        fas = CFSService.get_token(PaymentSystem.FAS)
+
+        paybc_cached = CFSService.get_token(PaymentSystem.PAYBC)
+        fas_cached = CFSService.get_token(PaymentSystem.FAS)
+
+    assert mock_post.call_count == 2
+    assert paybc.json().get("access_token") == paybc_token
+    assert fas.json().get("access_token") == fas_token
+    assert paybc_cached is paybc
+    assert fas_cached is fas
+
+
+def test_get_token_clears_cache_on_bad_response(session):
+    """A response without an access_token clears the stale cache entry."""
+    bad_response = MagicMock()
+    bad_response.json.return_value = {}
+
+    with patch("pay_api.services.oauth_service.requests.post", return_value=bad_response):
+        result = CFSService.get_token()
+
+    from pay_api.services.cfs_service import _token_cache
+    assert result is bad_response
+    assert "cfs_token_PAYBC" not in _token_cache


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/33375
https://github.com/bcgov/entity/issues/33380

*Description of changes:*
- add cfs token caching by key
- oauth service error logging, output request url

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
