### PR TITLE
34018 : Handling Pay Connector unavailable scenario

### DIFF
--- a/jobs/payment-jobs/poetry.lock
+++ b/jobs/payment-jobs/poetry.lock
@@ -2392,9 +2392,9 @@ werkzeug = "^3.1.4"
 
 [package.source]
 type = "git"
-url = "https://github.com/jxio/sbc-pay.git"
-reference = "33837"
-resolved_reference = "c920263f93f02781d6528e23b2d45ec61b62b80d"
+url = "https://github.com/sumesh85/sbc-pay.git"
+reference = "34018"
+resolved_reference = "7d3d80315efcceed35904d9acbfd8ff7cbc324da"
 subdirectory = "pay-api"
 
 [[package]]
@@ -3558,4 +3558,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "30641abe9d3bee03f5c9924135ec0e6e685e1d27f8ce5817358eb6fb540ff736"
+content-hash = "886c5b17cb506b2113e0b67723c597fa7732685377028b16d29a483979e27ca4"

--- a/jobs/payment-jobs/pyproject.toml
+++ b/jobs/payment-jobs/pyproject.toml
@@ -8,7 +8,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"
-pay-api = { git = "https://github.com/jxio/sbc-pay.git", branch = "33837", subdirectory = "pay-api" }
+pay-api = { git = "https://github.com/sumesh85/sbc-pay.git", branch = "34018", subdirectory = "pay-api" }
 mako = "1.3.12"
 pyasn1 = "0.6.3"
 flask = "^3.0.2"

--- a/jobs/payment-jobs/tests/jobs/test_stale_payment_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_stale_payment_task.py
@@ -148,6 +148,3 @@ def test_delete_marked_payments_direct_pay(session, connector_scenario, expected
 
     updated_invoice = InvoiceModel.find_by_id(invoice.id)
     assert updated_invoice.invoice_status_code == expected_invoice_status
-
-    assert payment.id is not None
-    assert payment.payment_status_code == PaymentStatus.COMPLETED.value

--- a/jobs/payment-jobs/tests/jobs/test_stale_payment_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_stale_payment_task.py
@@ -18,11 +18,13 @@ Test-Suite to ensure that the StalePaymentTask is working as expected.
 """
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from requests.exceptions import HTTPError
 
 from pay_api.models import CfsAccount as CfsAccountModel
+from pay_api.models import Invoice as InvoiceModel
 from pay_api.models import PaymentAccount as PaymentAccountModel
 from pay_api.models import PaymentTransaction as PaymentTransactionModel
 from pay_api.utils.enums import InvoiceStatus, PaymentMethod, PaymentStatus, TransactionStatus
@@ -109,6 +111,43 @@ def test_verify_created_credit_card_invoices(
 
     assert invoice.id is not None
     assert invoice.invoice_status_code == InvoiceStatus.PAID.value
+
+
+@pytest.mark.parametrize(
+    "connector_scenario, expected_invoice_status",
+    [
+        ("connector_down", InvoiceStatus.DELETE_ACCEPTED.value),
+        ("not_paid", InvoiceStatus.DELETED.value),
+    ],
+)
+def test_delete_marked_payments_direct_pay(session, connector_scenario, expected_invoice_status):
+    """Assert _delete_marked_payments skips DIRECT_PAY invoice when pay-connector is down and deletes when NOT PAID."""
+    account = factory_create_pad_account(auth_account_id="1234", payment_method=PaymentMethod.DIRECT_PAY.value)
+    invoice = factory_invoice(
+        payment_account=account,
+        status_code=InvoiceStatus.DELETE_ACCEPTED.value,
+        payment_method_code=PaymentMethod.DIRECT_PAY.value,
+    )
+    factory_invoice_reference(invoice_id=invoice.id, invoice_number=f"TEST-{invoice.id}")
+
+    if connector_scenario == "connector_down":
+        mock_side_effect = HTTPError("502 Server Error")
+        mock_return = None
+    else:
+        mock_order_status = MagicMock()
+        mock_order_status.paymentstatus = "DECLINED"
+        mock_side_effect = None
+        mock_return = mock_order_status
+
+    with patch(
+        "pay_api.services.payment_service.DirectSaleService.query_order_status",
+        side_effect=mock_side_effect,
+        return_value=mock_return,
+    ):
+        StalePaymentTask._delete_marked_payments()
+
+    updated_invoice = InvoiceModel.find_by_id(invoice.id)
+    assert updated_invoice.invoice_status_code == expected_invoice_status
 
     assert payment.id is not None
     assert payment.payment_status_code == PaymentStatus.COMPLETED.value

--- a/pay-api/src/pay_api/services/direct_sale_service.py
+++ b/pay-api/src/pay_api/services/direct_sale_service.py
@@ -297,6 +297,7 @@ class DirectSaleService(PaymentSystemService, OAuthService):
         """Get the receipt details by calling PayBC web service."""
         # If pay_response_url is present do all the pre-check, else check the status by using the invoice id
         current_app.logger.debug(f"Getting receipt details for invoice {invoice_reference.invoice_id}")
+        trn_approved = None
         if pay_response_url:
             parsed_args = parse_url_params(pay_response_url)
 

--- a/pay-api/src/pay_api/services/direct_sale_service.py
+++ b/pay-api/src/pay_api/services/direct_sale_service.py
@@ -311,8 +311,6 @@ class DirectSaleService(PaymentSystemService, OAuthService):
                     f"Transaction approved but hash mismatch for invoice {invoice_reference.invoice_id}"
                 )
                 return None
-            if trn_approved == "0":
-                return None
             # Get the transaction number from args
             paybc_transaction_number = parsed_args.get("pbcTxnNumber")
 
@@ -339,6 +337,10 @@ class DirectSaleService(PaymentSystemService, OAuthService):
                 additional_headers={"Pay-Connector": current_app.config.get("PAY_CONNECTOR_AUTH")},
             )
         except Exception as exc:
+            # If the connector is down and the payment was declined, treat as failed — no need to verify.
+            # If approved, we must not proceed without confirmation from PayBC.
+            if trn_approved == "0":
+                return None
             raise ServiceUnavailableException(exc) from exc
 
         if transaction_response:

--- a/pay-api/src/pay_api/services/direct_sale_service.py
+++ b/pay-api/src/pay_api/services/direct_sale_service.py
@@ -53,7 +53,7 @@ from pay_api.utils.enums import (
 )
 from pay_api.utils.util import current_local_time, generate_transaction_number, parse_url_params
 
-from ..exceptions import BusinessException  # noqa: TID252
+from ..exceptions import BusinessException, ServiceUnavailableException  # noqa: TID252
 from ..utils.errors import Error  # noqa: TID252
 from ..utils.paybc_transaction_error_message import PAYBC_TRANSACTION_ERROR_MESSAGE_DICT  # noqa: TID252
 from .oauth_service import OAuthService
@@ -311,6 +311,8 @@ class DirectSaleService(PaymentSystemService, OAuthService):
                     f"Transaction approved but hash mismatch for invoice {invoice_reference.invoice_id}"
                 )
                 return None
+            if trn_approved == "0":
+                return None
             # Get the transaction number from args
             paybc_transaction_number = parsed_args.get("pbcTxnNumber")
 
@@ -323,19 +325,21 @@ class DirectSaleService(PaymentSystemService, OAuthService):
             return None
 
         # Call PAYBC web service, get access token and use it in get txn call
-        access_token = self.get_token().json().get("access_token")
-
         paybc_transaction_url: str = current_app.config.get("PAYBC_DIRECT_PAY_BASE_URL")
         paybc_ref_number: str = current_app.config.get("PAYBC_DIRECT_PAY_REF_NUMBER")
 
-        transaction_response = self.get(
-            f"{paybc_transaction_url}/paybc/payment/{paybc_ref_number}/{paybc_transaction_number}",
-            access_token,
-            AuthHeaderType.BEARER,
-            ContentType.JSON,
-            return_none_if_404=True,
-            additional_headers={"Pay-Connector": current_app.config.get("PAY_CONNECTOR_AUTH")},
-        )
+        try:
+            access_token = self.get_token().json().get("access_token")
+            transaction_response = self.get(
+                f"{paybc_transaction_url}/paybc/payment/{paybc_ref_number}/{paybc_transaction_number}",
+                access_token,
+                AuthHeaderType.BEARER,
+                ContentType.JSON,
+                return_none_if_404=True,
+                additional_headers={"Pay-Connector": current_app.config.get("PAY_CONNECTOR_AUTH")},
+            )
+        except Exception as exc:
+            raise ServiceUnavailableException(exc) from exc
 
         if transaction_response:
             response_json = transaction_response.json()

--- a/pay-api/src/pay_api/services/payment_service.py
+++ b/pay-api/src/pay_api/services/payment_service.py
@@ -466,10 +466,11 @@ def _paybc_receipt_is_synced(invoice: Invoice):
         # check existing payment status in PayBC and save receipt
         PaymentTransaction.update_transaction(transaction.id, pay_response_url=None)
     except Exception as e:
-        current_app.logger.info(
-            f"PAYBC status for invoice {invoice.id} not found during delete check: {str(e)}",
+        current_app.logger.error(
+            f"PAYBC unavailable while verifying invoice {invoice.id} before delete: {str(e)}",
             exc_info=True,
         )
+        raise BusinessException(Error.SERVICE_UNAVAILABLE) from e
     else:
         raise BusinessException(Error.COMPLETED_PAYMENT)
 

--- a/pay-api/tests/unit/api/test_payment_request.py
+++ b/pay-api/tests/unit/api/test_payment_request.py
@@ -358,7 +358,7 @@ def test_delete_completed_payment(session, client, jwt, app):
 
 
 def test_payment_delete_when_paybc_is_down(session, client, jwt, app):
-    """Assert that the endpoint returns 202. The payment will be acceoted to delete."""
+    """Assert that deleting a DIRECT_PAY invoice returns 503 when pay-connector is down."""
     token = jwt.create_jwt(get_claims(), token_header)
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
 
@@ -374,7 +374,7 @@ def test_payment_delete_when_paybc_is_down(session, client, jwt, app):
         side_effect=ConnectionError("mocked error"),
     ):
         rv = client.delete(f"/api/v1/payment-requests/{pay_id}", headers=headers)
-        assert rv.status_code == 202
+        assert rv.status_code == 503
 
 
 def test_delete_direct_pay_invoice_blocks_deletion(session, client, jwt, app, auth_mock, mocker):

--- a/pay-api/tests/unit/services/test_direct_sale_service.py
+++ b/pay-api/tests/unit/services/test_direct_sale_service.py
@@ -377,16 +377,16 @@ _APPROVED_RESPONSE_URL = (
     "scenario, pay_response_url, get_token_raises, expected_exception",
     [
         (
-            "declined_no_connector_call",
+            "declined_connector_down",
             "trnApproved=0&trnOrderId=1003598&trnAmount=201.00&pbcTxnNumber=1",
-            False,
-            None,
+            True,
+            None,  # connector down + declined → safe to return None without verifying
         ),
         (
             "approved_connector_down",
             None,  # built in test using _APPROVED_RESPONSE_URL + valid hash
             True,
-            "ServiceUnavailableException",
+            "ServiceUnavailableException",  # connector down + approved → must not proceed
         ),
         (
             "no_url_connector_down",
@@ -411,7 +411,7 @@ def test_get_receipt_pay_connector_scenarios(
     direct_pay_service = DirectSaleService()
 
     token_side_effect = HTTPError("502 Server Error") if get_token_raises else None
-    with patch.object(DirectSaleService, "get_token", side_effect=token_side_effect) as mock_get_token:
+    with patch.object(DirectSaleService, "get_token", side_effect=token_side_effect):
         if expected_exception:
             with pytest.raises(Exception) as excinfo:
                 direct_pay_service.get_receipt(payment_account, pay_response_url, invoice_ref)
@@ -419,7 +419,6 @@ def test_get_receipt_pay_connector_scenarios(
         else:
             rcpt = direct_pay_service.get_receipt(payment_account, pay_response_url, invoice_ref)
             assert rcpt is None
-            mock_get_token.assert_not_called()
 
 
 def test_process_cfs_refund_success(session, monkeypatch):

--- a/pay-api/tests/unit/services/test_direct_sale_service.py
+++ b/pay-api/tests/unit/services/test_direct_sale_service.py
@@ -367,6 +367,61 @@ def test_get_receipt(session, public_user_mock):
     assert rcpt is not None
 
 
+_APPROVED_RESPONSE_URL = (
+    "trnApproved=1&messageText=Approved&trnOrderId=1003598&trnAmount=201.00&paymentMethod=CC"
+    "&cardType=VI&authCode=TEST&trnDate=2020-08-11&pbcTxnNumber=1"
+)
+
+
+@pytest.mark.parametrize(
+    "scenario, pay_response_url, get_token_raises, expected_exception",
+    [
+        (
+            "declined_no_connector_call",
+            "trnApproved=0&trnOrderId=1003598&trnAmount=201.00&pbcTxnNumber=1",
+            False,
+            None,
+        ),
+        (
+            "approved_connector_down",
+            None,  # built in test using _APPROVED_RESPONSE_URL + valid hash
+            True,
+            "ServiceUnavailableException",
+        ),
+        (
+            "no_url_connector_down",
+            None,
+            True,
+            "ServiceUnavailableException",
+        ),
+    ],
+)
+def test_get_receipt_pay_connector_scenarios(
+    session, public_user_mock, scenario, pay_response_url, get_token_raises, expected_exception
+):
+    """Assert get_receipt handles declined payments, connector outages, and missing URL correctly."""
+    if scenario == "approved_connector_down":
+        pay_response_url = f"{_APPROVED_RESPONSE_URL}&hashValue={HashingService.encode(_APPROVED_RESPONSE_URL)}"
+
+    payment_account = factory_payment_account()
+    payment_account.save()
+    invoice = factory_invoice(payment_account)
+    invoice.save()
+    invoice_ref = factory_invoice_reference(invoice.id).save()
+    direct_pay_service = DirectSaleService()
+
+    token_side_effect = HTTPError("502 Server Error") if get_token_raises else None
+    with patch.object(DirectSaleService, "get_token", side_effect=token_side_effect) as mock_get_token:
+        if expected_exception:
+            with pytest.raises(Exception) as excinfo:
+                direct_pay_service.get_receipt(payment_account, pay_response_url, invoice_ref)
+            assert excinfo.type.__name__ == expected_exception
+        else:
+            rcpt = direct_pay_service.get_receipt(payment_account, pay_response_url, invoice_ref)
+            assert rcpt is None
+            mock_get_token.assert_not_called()
+
+
 def test_process_cfs_refund_success(session, monkeypatch):
     """Assert refund is successful, when providing a PAID invoice, receipt, a COMPLETED invoice reference."""
     payment_account = factory_payment_account()

--- a/pay-api/tests/unit/services/test_payment_service.py
+++ b/pay-api/tests/unit/services/test_payment_service.py
@@ -34,6 +34,7 @@ from pay_api.services.payment_account import PaymentAccount as PaymentAccountSer
 from pay_api.services.payment_line_item import PaymentLineItem
 from pay_api.services.payment_service import PaymentService
 from pay_api.utils.enums import InvoiceStatus, PaymentMethod, PaymentStatus, RoutingSlipStatus
+from pay_api.utils.errors import Error
 from tests.utilities.base_test import (
     factory_corp_type_model,
     factory_distribution_code,
@@ -262,6 +263,24 @@ def test_delete_completed_payment(session, auth_mock):
     with pytest.raises(Exception) as excinfo:
         PaymentService.delete_invoice(invoice.id)
     assert excinfo.type == BusinessException
+
+
+def test_delete_direct_pay_invoice_pay_connector_down(session, auth_mock, public_user_mock):
+    """Assert delete_invoice raises SERVICE_UNAVAILABLE when pay-connector is unreachable for a DIRECT_PAY invoice."""
+    payment_account = factory_payment_account()
+    payment_account.save()
+    invoice = factory_invoice(payment_account, payment_method_code=PaymentMethod.DIRECT_PAY.value)
+    invoice.save()
+    invoice_reference = factory_invoice_reference(invoice.id).save()
+    factory_payment(invoice_number=invoice_reference.invoice_number).save()
+
+    with patch(
+        "pay_api.services.payment_service.DirectSaleService.query_order_status",
+        side_effect=HTTPError("502 Server Error"),
+    ):
+        with pytest.raises(BusinessException) as excinfo:
+            PaymentService.delete_invoice(invoice.id)
+        assert excinfo.value.code == Error.SERVICE_UNAVAILABLE.code
 
 
 def test_create_bcol_payment(session, public_user_mock):


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/34018

*Description of changes:*
- Handled paybc connector errors and update the status of transaction to SERVICE_UNAVAILABLE
- In case of errors; check if txnApproved is 0 or 1 to decide on the status
- Added test cases to mimic the scenarios


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
