### PR TITLE
33757 - Charge service fees for staff

### DIFF
--- a/pay-api/src/pay_api/services/fee_schedule.py
+++ b/pay-api/src/pay_api/services/fee_schedule.py
@@ -423,9 +423,10 @@ class FeeSchedule:  # pylint: disable=too-many-public-methods, too-many-instance
 
         service_fees: float = 0
 
+        # Staff are charged service fees (leadership decision, 2026-07 — see entity#33757).
+        # To exempt staff again, add `not user.is_staff()` back to this condition.
         if (
-            not user.is_staff()
-            and not (user.is_system() and Role.EXCLUDE_SERVICE_FEES.value in user.roles)
+            not (user.is_system() and Role.EXCLUDE_SERVICE_FEES.value in user.roles)
             and fee_schedule_model.fee.amount > 0
             and fee_schedule_model.service_fee
         ):

--- a/pay-api/src/pay_api/version.py
+++ b/pay-api/src/pay_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = "1.25.2"  # pylint: disable=invalid-name
+__version__ = "1.25.3"  # pylint: disable=invalid-name

--- a/pay-api/tests/unit/api/test_fee.py
+++ b/pay-api/tests/unit/api/test_fee.py
@@ -225,6 +225,28 @@ def test_calculate_fees_for_service_fee(session, client, jwt, app):
     assert rv.json.get("serviceFees") == 1.5
 
 
+def test_calculate_fees_for_service_fee_for_staff(session, client, jwt, app):
+    """Assert staff are charged the service fee (entity#33757 leadership decision)."""
+    token = jwt.create_jwt(get_claims(role="staff"), token_header)
+    headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
+
+    corp_type = "XX"
+    filing_type_code = "XOTANN"
+    service_fee = factory_fee_model("SF01", 1.5)
+    factory_fee_schedule_model(
+        factory_filing_type_model("XOTANN", "TEST"),
+        factory_corp_type_model("XX", "TEST"),
+        factory_fee_model("XXX", 100),
+        service_fee=service_fee,
+    )
+
+    rv = client.get(f"/api/v1/fees/{corp_type}/{filing_type_code}", headers=headers)
+    assert rv.status_code == 200
+    assert schema_utils.validate(rv.json, "fees")[0]
+    assert rv.json.get("filingFees") == 100
+    assert rv.json.get("serviceFees") == 1.5
+
+
 def test_calculate_fees_with_zero_service_fee(session, client, jwt, app):
     """Assert that service fee is zero if the filing fee is zero."""
     token = jwt.create_jwt(get_claims(), token_header)


### PR DESCRIPTION
Issue #: bcgov/entity#33757

Staff are now charged the service fee per the updated leadership decision; the previous staff exemption can be restored by re-adding `not user.is_staff()` (see code comment).