### PR TITLE
33933 - account linking

### DIFF
--- a/pay-api/src/pay_api/services/auth.py
+++ b/pay-api/src/pay_api/services/auth.py
@@ -89,8 +89,16 @@ def check_auth(
                 current_app.config.get("AUTH_API_ENDPOINT")
                 + f"entities/{business_identifier}/authorizations?expanded=true"
             )
+            additional_headers = {"Account-Linking-Key": user.linking_key} if user.linking_key else None
             auth_response = (
-                RestService.get(auth_url, bearer_token, AuthHeaderType.BEARER, ContentType.JSON).json() or {}
+                RestService.get(
+                    auth_url,
+                    bearer_token,
+                    AuthHeaderType.BEARER,
+                    ContentType.JSON,
+                    additional_headers=additional_headers,
+                ).json()
+                or {}
             )
 
             roles: list = auth_response.get("roles", [])

--- a/pay-api/src/pay_api/services/payment_account.py
+++ b/pay-api/src/pay_api/services/payment_account.py
@@ -514,7 +514,9 @@ class PaymentAccount:  # pylint: disable=too-many-instance-attributes, too-many-
     def find_account(cls, authorization: dict[str, Any]) -> PaymentAccount | None:
         """Find payment account by corp number, corp type and payment system code."""
         current_app.logger.debug("<find_payment_account")
-        auth_account_id: str = get_str_by_path(authorization, "account/id")
+        auth_account_id: str = get_str_by_path(authorization, "account/paymentAccountId") or get_str_by_path(
+            authorization, "account/id"
+        )
         return PaymentAccount.find_by_auth_account_id(auth_account_id)
 
     @classmethod

--- a/pay-api/src/pay_api/services/payment_service.py
+++ b/pay-api/src/pay_api/services/payment_service.py
@@ -222,7 +222,8 @@ class PaymentService:  # pylint: disable=too-few-public-methods
             )
             payment_account = PaymentAccount.create(
                 {
-                    "accountId": get_str_by_path(authorization, "account/id"),
+                    "accountId": get_str_by_path(authorization, "account/paymentAccountId")
+                    or get_str_by_path(authorization, "account/id"),
                     "paymentInfo": {"methodOfPayment": payment_method},
                 }
             )

--- a/pay-api/src/pay_api/utils/user_context.py
+++ b/pay-api/src/pay_api/utils/user_context.py
@@ -62,6 +62,7 @@ class UserContext:  # pylint: disable=too-many-instance-attributes
         self._sub: str = token_info.get("sub", None)
         self._login_source: str = token_info.get("loginSource", None)
         self._account_id: str = get_auth_account_id()
+        self._linking_key: str = get_account_linking_key()
         self._name = token_info.get("name", None)
         self._product_code: str = token_info.get("product_code", None)
         self._permission = _get_permission()
@@ -106,6 +107,11 @@ class UserContext:  # pylint: disable=too-many-instance-attributes
     def account_id(self) -> str:
         """Return the account_id."""
         return self._account_id
+
+    @property
+    def linking_key(self) -> str:
+        """Return the account linking key."""
+        return self._linking_key
 
     @property
     def permission(self) -> list[str]:
@@ -179,6 +185,11 @@ def get_auth_account_id() -> str:
     if not account_id:
         account_id = request.headers["Account-Id"] if request and "Account-Id" in request.headers else None
     return account_id
+
+
+def get_account_linking_key() -> str:
+    """Return the account linking key from the header."""
+    return request.headers.get("Account-Linking-Key") if request else None
 
 
 def get_original_user_sub(is_system: bool) -> str:

--- a/pay-api/tests/conftest.py
+++ b/pay-api/tests/conftest.py
@@ -15,7 +15,7 @@
 """Common setup and fixtures for the py-test suite used by this service."""
 
 import os
-from unittest.mock import DEFAULT, patch
+from unittest.mock import DEFAULT, MagicMock, patch
 
 import pytest
 from flask_migrate import Migrate, upgrade
@@ -165,6 +165,26 @@ def clear_cfs_token_cache():
 def auth_mock(monkeypatch):
     """Mock check_auth."""
     monkeypatch.setattr("pay_api.services.auth.check_auth", lambda *args, **kwargs: None)  # noqa: ARG005
+
+
+@pytest.fixture()
+def linking_key_auth_mock():
+    """Return a factory for a RestService.get side-effect mimicking auth-api's linking-key authorization response."""
+
+    def _factory(source_account_id: str, vendor_account_id: str, roles: list = None):
+        def _mock(url, *args, **kwargs):  # noqa: ARG001
+            additional_headers = kwargs.get("additional_headers") or {}
+            payment_account_id = vendor_account_id if "Account-Linking-Key" in additional_headers else source_account_id
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "roles": roles or ["edit", "view", "make_payment"],
+                "account": {"id": source_account_id, "paymentAccountId": payment_account_id},
+            }
+            return mock_response
+
+        return _mock
+
+    return _factory
 
 
 @pytest.fixture()

--- a/pay-api/tests/unit/api/test_payment_request.py
+++ b/pay-api/tests/unit/api/test_payment_request.py
@@ -31,6 +31,7 @@ from pay_api.models import CorpType, FeeCode, FilingType
 from pay_api.models import DistributionCode as DistributionCodeModel
 from pay_api.models import DistributionCodeLink as DistributionCodeLinkModel
 from pay_api.models import FeeSchedule as FeeScheduleModel
+from pay_api.models import Invoice as InvoiceModel
 from pay_api.models import PaymentAccount as PaymentAccountModel
 from pay_api.models import RoutingSlip as RoutingSlipModel
 from pay_api.models.tax_rate import TaxRate
@@ -1879,3 +1880,83 @@ def test_payment_request_gst_field_behavior(session, client, jwt, app):
         assert line_item["gst"] == 0, "Line item GST amount should be 0 when invoice has no GST"
         assert "statutoryFeesGst" not in line_item, "statutoryFeesGst should be hidden when invoice has no GST"
         assert "serviceFeesGst" not in line_item, "serviceFeesGst should be hidden when invoice has no GST"
+
+
+@pytest.mark.parametrize(
+    "linking_key_header",
+    [
+        {"Account-Linking-Key": "test-linking-key"},
+        {},
+    ],
+)
+def test_payment_request_creation_with_linking_key(
+    session, client, jwt, app, linking_key_auth_mock, linking_key_header
+):
+    """Assert invoice is created under the vendor account when a linking key is provided
+    and under the source account otherwise (paymentAccountId falls back to account.id).
+    """
+    source_account_id = "88888"
+    vendor_account_id = "99999"
+    expected_account_id = vendor_account_id if linking_key_header else source_account_id
+
+    token = jwt.create_jwt(get_claims(), token_header)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "content-type": "application/json",
+        **linking_key_header,
+    }
+
+    with patch(
+        "pay_api.services.auth.RestService.get",
+        side_effect=linking_key_auth_mock(source_account_id, vendor_account_id),
+    ) as mock_get:
+        rv = client.post("/api/v1/payment-requests", data=json.dumps(get_payment_request()), headers=headers)
+
+    assert rv.status_code == 201
+
+    called_additional_headers = mock_get.call_args.kwargs.get("additional_headers")
+    if linking_key_header:
+        assert called_additional_headers == linking_key_header
+    else:
+        assert called_additional_headers is None
+
+    # Assert the invoice's payment account resolves to the expected (vendor vs source) auth account id.
+    invoice = InvoiceModel.find_by_id(rv.json.get("id"))
+    payment_account = PaymentAccountModel.find_by_id(invoice.payment_account_id)
+    assert payment_account.auth_account_id == expected_account_id
+
+
+def test_payment_request_creation_account_id_ignores_linking_key(session, client, jwt, app, linking_key_auth_mock):
+    """Assert Account-Linking-Key has no effect when the caller already has an Account-Id present.
+
+    Vendor-account invoice creation via a linking key is used when only business_identifier exists for check_auth
+    (i.e. business-filing invoices). When Account-Id is present, check_auth
+    takes the org-based branch instead, which never forwards Account-Linking-Key to auth-api, so
+    the invoice must still be created under the source account.
+    """
+    source_account_id = "77777"
+    vendor_account_id = "99999"
+
+    token = jwt.create_jwt(get_claims(), token_header)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "content-type": "application/json",
+        "Account-Id": source_account_id,
+        "Account-Linking-Key": "attempted-linking-key",
+    }
+
+    with patch(
+        "pay_api.services.auth.RestService.get",
+        side_effect=linking_key_auth_mock(source_account_id, vendor_account_id),
+    ) as mock_get:
+        rv = client.post("/api/v1/payment-requests", data=json.dumps(get_payment_request()), headers=headers)
+
+    assert rv.status_code == 201
+
+    # Linking key should not be included as this is not a business-filing invoice.
+    called_additional_headers = mock_get.call_args.kwargs.get("additional_headers")
+    assert not called_additional_headers or "Account-Linking-Key" not in called_additional_headers
+
+    invoice = InvoiceModel.find_by_id(rv.json.get("id"))
+    payment_account = PaymentAccountModel.find_by_id(invoice.payment_account_id)
+    assert payment_account.auth_account_id == source_account_id

--- a/pay-api/tests/unit/api/test_payment_request.py
+++ b/pay-api/tests/unit/api/test_payment_request.py
@@ -1892,9 +1892,7 @@ def test_payment_request_gst_field_behavior(session, client, jwt, app):
 def test_payment_request_creation_with_linking_key(
     session, client, jwt, app, linking_key_auth_mock, linking_key_header
 ):
-    """Assert invoice is created under the vendor account when a linking key is provided
-    and under the source account otherwise (paymentAccountId falls back to account.id).
-    """
+    """Assert invoice is created under the appropriate account based on the presence of a linking key."""
     source_account_id = "88888"
     vendor_account_id = "99999"
     expected_account_id = vendor_account_id if linking_key_header else source_account_id

--- a/pay-api/tests/unit/services/test_auth.py
+++ b/pay-api/tests/unit/services/test_auth.py
@@ -162,3 +162,23 @@ def test_get_account_info_with_contact(session, public_user_mock, contacts, expe
         )
 
     assert account_info["contact"] == expected_contact
+
+
+@pytest.mark.parametrize(
+    "linking_key_header,expected_additional_headers",
+    [
+        ("some-linking-key", {"Account-Linking-Key": "some-linking-key"}),
+        (None, None),
+    ],
+)
+def test_check_auth_forwards_linking_key_for_business_identifier(
+    app, session, public_user_mock, linking_key_header, expected_additional_headers
+):
+    """Assert check_auth forwards the Account-Linking-Key header on the business-identifier branch."""
+    headers = {"Account-Linking-Key": linking_key_header} if linking_key_header else {}
+    with app.test_request_context(headers=headers):
+        with patch("pay_api.services.auth.RestService.get") as mock_get:
+            mock_get.return_value.json.return_value = {"roles": [EDIT_ROLE], "account": {"id": "1234"}}
+            check_auth("CP0001234", contains_role=EDIT_ROLE)
+
+        assert mock_get.call_args.kwargs["additional_headers"] == expected_additional_headers


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/33933

*Description of changes:*
- account linking key forward on check_auth for business filing transactions
- use returned paymentAccountId (vendor org id) returned from auth response for linking key business transactions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
