### PR TITLE
Properly hand 5xx error messages in OauthService

### DIFF
--- a/pay-api/src/pay_api/services/oauth_service.py
+++ b/pay-api/src/pay_api/services/oauth_service.py
@@ -108,7 +108,10 @@ class OAuthService:
             current_app.logger.error(
                 f"HTTPError on POST with status code {exc.response.status_code if exc.response is not None else ''} {endpoint}"
             )
-            if exc.response and exc.response.status_code >= 500:
+            # `if exc.response` is a trap — Response.__bool__ returns False for any
+            # non-2xx (implemented as .ok), so a 502 here evaluates falsy and skips
+            # the 5xx-to-ServiceUnavailable conversion. Same fix as OAuthService.get.
+            if exc.response is not None and exc.response.status_code >= 500:
                 raise ServiceUnavailableException(exc) from exc
             raise exc
         finally:


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
Fix OAuthService.post so 5xx responses from services (e.g. pay-connector) are correctly re-raised as ServiceUnavailableException.
the previous `if exc.response and …` check hit `requests.Response.__bool__` (which  returns False for any non-2xx), so the 5xx branch was silently skipped.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
