### PR TITLE
34628 - roll back and notify on routing slip job CAS failures

### DIFF
--- a/jobs/payment-jobs/tasks/routing_slip_task.py
+++ b/jobs/payment-jobs/tasks/routing_slip_task.py
@@ -118,7 +118,9 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                     f"routing slip : {routing_slip.id}, ERROR : {str(e)}",
                     exc_info=True,
                 )
-                rollback_ok = cls._rollback_failed_link(routing_slip, parent_rs, parent_rs_remaining_after_sync_link)
+                rollback_ok = cls._rollback_and_hold_failed_link(
+                    routing_slip, parent_rs, parent_rs_remaining_after_sync_link
+                )
                 failures.append((routing_slip.number, cls._failure_message(e, rollback_ok)))
                 continue
 
@@ -412,7 +414,7 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
         return (pending_invoice_count > 0, pending_invoice_count)
 
     @classmethod
-    def _rollback_failed_link(
+    def _rollback_and_hold_failed_link(
         cls,
         routing_slip: RoutingSlipModel,
         parent_rs: RoutingSlipModel,
@@ -452,7 +454,7 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
 
     @classmethod
     def _rollback_failed_correction(cls, routing_slip: RoutingSlipModel, cas_version_suffix: int) -> bool:
-        """Undo the version bump from a failed correction. See _rollback_failed_link for the pattern."""
+        """Undo the version bump from a failed correction. See _rollback_and_hold_failed_link for the pattern."""
         try:
             routing_slip.cas_version_suffix = cas_version_suffix
             routing_slip.save()
@@ -472,7 +474,7 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
         remaining_amount: Decimal,
         cas_version_suffix: int,
     ) -> bool:
-        """Undo our own changes from a failed void. See _rollback_failed_link for the pattern."""
+        """Undo our own changes from a failed void. See _rollback_and_hold_failed_link for the pattern."""
         try:
             if cfs_account is not None:
                 cfs_account.status = CfsAccountStatus.ACTIVE.value

--- a/jobs/payment-jobs/tasks/routing_slip_task.py
+++ b/jobs/payment-jobs/tasks/routing_slip_task.py
@@ -192,18 +192,7 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                     f"Error on Processing CORRECTION for :={rs.number}, routing slip : {rs.id}, ERROR : {str(e)}",
                     exc_info=True,
                 )
-                # Only the cas_version_suffix bump is undone. A reversal that already went through in
-                # CAS stays reversed - the next run detects that and skips re-reversing it.
-                rollback_ok = True
-                try:
-                    rs.cas_version_suffix = cas_version_suffix_snapshot
-                    rs.save()
-                except Exception as rollback_error:  # NOQA # pylint: disable=broad-except
-                    rollback_ok = False
-                    current_app.logger.error(
-                        f"Rollback failed for Routing Slip number:={rs.number}, ERROR : {str(rollback_error)}",
-                        exc_info=True,
-                    )
+                rollback_ok = cls._rollback_failed_correction(rs, cas_version_suffix_snapshot)
                 failures.append((rs.number, cls._failure_message(e, rollback_ok)))
                 continue
 
@@ -268,31 +257,12 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                     f"routing slip : {routing_slip.id}, ERROR : {str(e)}",
                     exc_info=True,
                 )
-                # Only our own DB-side changes are undone. Receipts already reversed in CAS stay
-                # reversed - the next run detects that and skips re-reversing them.
-                rollback_ok = True
-                try:
-                    if cfs_account is not None:
-                        cfs_account.status = CfsAccountStatus.ACTIVE.value
-                    routing_slip.remaining_amount = remaining_amount_snapshot
-                    routing_slip.cas_version_suffix = cas_version_suffix_snapshot
-                    routing_slip.save()
-                except Exception as rollback_error:  # NOQA # pylint: disable=broad-except
-                    rollback_ok = False
-                    current_app.logger.error(
-                        f"Rollback failed for Routing Slip number:={routing_slip.number}, ERROR : {str(rollback_error)}",
-                        exc_info=True,
-                    )
-                message = cls._failure_message(e, rollback_ok)
-                if reversed_numbers:
-                    # Only worth saying when the group was partly processed - these receipts are
-                    # already reversed in CAS and can't be re-reversed on a retry.
-                    all_numbers = [routing_slip.number] + [rs.number for rs in child_routing_slips]
-                    not_yet_reversed = [number for number in all_numbers if number not in reversed_numbers]
-                    message += (
-                        f" Already reversed in CAS: {', '.join(reversed_numbers)};"
-                        f" not yet reversed: {', '.join(not_yet_reversed) or 'none'}."
-                    )
+                rollback_ok = cls._rollback_failed_void(
+                    routing_slip, cfs_account, remaining_amount_snapshot, cas_version_suffix_snapshot
+                )
+                message = cls._failure_message(e, rollback_ok) + cls._partial_reversal_note(
+                    routing_slip, child_routing_slips, reversed_numbers
+                )
                 failures.append((routing_slip.number, message))
                 continue
 
@@ -483,14 +453,68 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
             )
             return False
 
+    @classmethod
+    def _rollback_failed_correction(cls, routing_slip: RoutingSlipModel, cas_version_suffix: int) -> bool:
+        """Undo the version bump from a failed correction. See _rollback_failed_link for the pattern.
+
+        A reversal that already went through in CAS stays reversed - the next run detects that and
+        skips re-reversing it.
+        """
+        try:
+            routing_slip.cas_version_suffix = cas_version_suffix
+            routing_slip.save()
+            return True
+        except Exception as rollback_error:  # NOQA # pylint: disable=broad-except
+            current_app.logger.error(
+                f"Rollback failed for Routing Slip number:={routing_slip.number}, ERROR : {str(rollback_error)}",
+                exc_info=True,
+            )
+            return False
+
+    @classmethod
+    def _rollback_failed_void(
+        cls,
+        routing_slip: RoutingSlipModel,
+        cfs_account: CfsAccountModel,
+        remaining_amount: Decimal,
+        cas_version_suffix: int,
+    ) -> bool:
+        """Undo our own changes from a failed void. See _rollback_failed_link for the pattern.
+
+        Receipts already reversed in CAS stay reversed - the next run detects that and skips
+        re-reversing them.
+        """
+        try:
+            if cfs_account is not None:
+                cfs_account.status = CfsAccountStatus.ACTIVE.value
+            routing_slip.remaining_amount = remaining_amount
+            routing_slip.cas_version_suffix = cas_version_suffix
+            routing_slip.save()
+            return True
+        except Exception as rollback_error:  # NOQA # pylint: disable=broad-except
+            current_app.logger.error(
+                f"Rollback failed for Routing Slip number:={routing_slip.number}, ERROR : {str(rollback_error)}",
+                exc_info=True,
+            )
+            return False
+
+    @staticmethod
+    def _partial_reversal_note(
+        routing_slip: RoutingSlipModel, child_routing_slips: list[RoutingSlipModel], reversed_numbers: list[str]
+    ) -> str:
+        """Describe which members of a void group were already reversed in CAS, if any were."""
+        if not reversed_numbers:
+            return ""
+        all_numbers = [routing_slip.number] + [rs.number for rs in child_routing_slips]
+        not_yet_reversed = [number for number in all_numbers if number not in reversed_numbers]
+        return (
+            f" Already reversed in CAS: {', '.join(reversed_numbers)};"
+            f" not yet reversed: {', '.join(not_yet_reversed) or 'none'}."
+        )
+
     @staticmethod
     def _receipt_already_reversed(cfs_account: CfsAccountModel, receipt_number: str) -> bool:
-        """Whether CAS already has this receipt as reversed.
-
-        A partially-failed earlier attempt can leave the receipt reversed in CAS while our own
-        records still look untouched. Reversing an already-reversed receipt isn't guaranteed to be
-        safe, so callers skip that step when this returns True.
-        """
+        """Whether CAS already has this receipt as reversed."""
         return CFSService.get_receipt(cfs_account, receipt_number).get("status") == CfsReceiptStatus.REV.value
 
     @staticmethod

--- a/jobs/payment-jobs/tasks/routing_slip_task.py
+++ b/jobs/payment-jobs/tasks/routing_slip_task.py
@@ -58,11 +58,15 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
         2. Notify mailer
         """
         routing_slips = cls._get_routing_slip_by_status(RoutingSlipStatus.LINKED.value)
+        failures = []
         for routing_slip in routing_slips:
             # 1. Reverse the child routing slip.
             # 2. Create receipt to the parent.
             # 3. Change the payment account of child to parent.
             # 4. Change the status.
+            cfs_account = None
+            parent_rs = None
+            parent_rs_remaining_snapshot = None
             try:
                 current_app.logger.debug(f"Linking Routing Slip: {routing_slip.number}")
                 payment_account: PaymentAccountModel = PaymentAccountModel.find_by_id(routing_slip.payment_account_id)
@@ -76,7 +80,8 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                 cfs_account.status = CfsAccountStatus.INACTIVE.value
 
                 # apply receipt to parent cfs account
-                parent_rs: RoutingSlipModel = RoutingSlipModel.find_by_number(routing_slip.parent_number)
+                parent_rs = RoutingSlipModel.find_by_number(routing_slip.parent_number)
+                parent_rs_remaining_snapshot = parent_rs.remaining_amount
                 parent_payment_account: PaymentAccountModel = PaymentAccountModel.find_by_id(
                     parent_rs.payment_account_id
                 )
@@ -106,12 +111,24 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                 routing_slip.save()
 
             except Exception as e:  # NOQA # pylint: disable=broad-except
+                # Discard any uncommitted dirty state from this iteration (e.g. cfs_account.status)
+                # before touching anything - otherwise it can get swept into a later, unrelated commit.
+                db.session.rollback()
                 current_app.logger.error(
                     f"Error on Linking Routing Slip number:={routing_slip.number}, "
                     f"routing slip : {routing_slip.id}, ERROR : {str(e)}",
                     exc_info=True,
                 )
+                cls._rollback_failed_link(routing_slip, parent_rs, parent_rs_remaining_snapshot)
+                failures.append((routing_slip.number, str(e)))
                 continue
+
+        cls._notify_job_failures(
+            failures,
+            subject="Routing Slip Linking Job Failure",
+            file_name="routing_slip_linking",
+            job_name="Link Routing Slips Job",
+        )
 
     @classmethod
     def process_correction(cls):
@@ -126,7 +143,9 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
         """
         routing_slips = cls._get_routing_slip_by_status(RoutingSlipStatus.CORRECTION.value)
         current_app.logger.info(f"Found {len(routing_slips)} to process CORRECTIONS.")
+        failures = []
         for rs in routing_slips:
+            cas_version_suffix_snapshot = rs.cas_version_suffix
             try:
                 wait_for_create_invoice_job = any(
                     x.invoice_status_code in [InvoiceStatus.APPROVED.value, InvoiceStatus.CREATED.value]
@@ -167,11 +186,25 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
 
                 rs.save()
             except Exception as e:  # NOQA # pylint: disable=broad-except
+                db.session.rollback()
                 current_app.logger.error(
                     f"Error on Processing CORRECTION for :={rs.number}, routing slip : {rs.id}, ERROR : {str(e)}",
                     exc_info=True,
                 )
+                # Note: this only undoes the cas_version_suffix bump. If the original CAS receipt was
+                # already reversed before the failure, that reversal itself can't be undone from here -
+                # it needs the same manual recovery as any other CAS-side failure.
+                rs.cas_version_suffix = cas_version_suffix_snapshot
+                rs.save()
+                failures.append((rs.number, str(e)))
                 continue
+
+        cls._notify_job_failures(
+            failures,
+            subject="Routing Slip Correction Job Failure",
+            file_name="routing_slip_correction",
+            job_name="Routing Slip Correction Job",
+        )
 
     @classmethod
     def process_void(cls):
@@ -185,7 +218,11 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
         """
         routing_slips = cls._get_routing_slip_by_status(RoutingSlipStatus.VOID.value)
         current_app.logger.info(f"Found {len(routing_slips)} to process VOID.")
+        failures = []
         for routing_slip in routing_slips:
+            cfs_account = None
+            remaining_amount_snapshot = routing_slip.remaining_amount
+            cas_version_suffix_snapshot = routing_slip.cas_version_suffix
             try:
                 current_app.logger.debug(f"Reverse receipt {routing_slip.number}")
                 if routing_slip.invoices:
@@ -210,12 +247,29 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                 routing_slip.cas_version_suffix += 1
                 routing_slip.save()
             except Exception as e:  # NOQA # pylint: disable=broad-except
+                db.session.rollback()
                 current_app.logger.error(
                     f"Error on Processing VOID for :={routing_slip.number}, "
                     f"routing slip : {routing_slip.id}, ERROR : {str(e)}",
                     exc_info=True,
                 )
+                # Note: this only undoes our own DB-side changes for this attempt. Any receipt that
+                # was already reversed in CAS before the failure can't be undone from here - it needs
+                # the same manual recovery as any other CAS-side failure.
+                if cfs_account is not None:
+                    cfs_account.status = CfsAccountStatus.ACTIVE.value
+                routing_slip.remaining_amount = remaining_amount_snapshot
+                routing_slip.cas_version_suffix = cas_version_suffix_snapshot
+                routing_slip.save()
+                failures.append((routing_slip.number, str(e)))
                 continue
+
+        cls._notify_job_failures(
+            failures,
+            subject="Routing Slip Void Job Failure",
+            file_name="routing_slip_void",
+            job_name="Routing Slip Void Job",
+        )
 
     @classmethod
     def process_nsf(cls):
@@ -359,6 +413,61 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
         return (pending_invoice_count > 0, pending_invoice_count)
 
     @classmethod
+    def _rollback_failed_link(
+        cls,
+        routing_slip: RoutingSlipModel,
+        parent_rs: RoutingSlipModel,
+        parent_rs_remaining_snapshot: Decimal,
+    ) -> None:
+        """Undo the do_link changes so a failed link doesn't leave a half-migrated routing slip.
+
+        - db.session.rollback() (called by the caller before this) only undoes changes made during
+          this job run. It can't touch routing_slip.status/parent_number or the parent's
+          remaining_amount - those were already committed by the earlier, synchronous do_link API
+          call, in a separate transaction - so this method reverses them explicitly.
+        - Goes to HOLD, not ACTIVE: we can't tell from here whether the CAS receipt was already
+          reversed before the failure. HOLD blocks any spend either way, so it's safe regardless.
+          ACTIVE would be wrong if the receipt is gone and the balance isn't backed by anything in CAS.
+        - cfs_account is left as-is for the same reason.
+        - A person must check the real CAS state (see the routing slip unlink runbook) before moving
+          this back to ACTIVE.
+        """
+        try:
+            if parent_rs is not None and parent_rs_remaining_snapshot is not None:
+                parent_rs.remaining_amount = parent_rs_remaining_snapshot - routing_slip.total
+                parent_rs.save()
+            routing_slip.status = RoutingSlipStatus.HOLD.value
+            routing_slip.parent_number = None
+            routing_slip.remaining_amount = routing_slip.total
+            routing_slip.save()
+        except Exception as rollback_error:  # NOQA # pylint: disable=broad-except
+            current_app.logger.error(
+                f"Rollback failed for Routing Slip number:={routing_slip.number}, ERROR : {str(rollback_error)}",
+                exc_info=True,
+            )
+
+    @classmethod
+    def _notify_job_failures(cls, failures: list[tuple[str, str]], subject: str, file_name: str, job_name: str) -> None:
+        """Send a single summary notification for all routing slips that failed in this job run."""
+        if not failures:
+            return
+        action_message = (
+            "Action needed: verify the real CAS receipt state for each routing slip below before "
+            "assuming its recorded balance is safe to use - do not rely on PAYDB's numbers alone."
+        )
+        notification = JobFailureNotification(
+            subject=subject,
+            file_name=file_name,
+            error_messages=[
+                {"error": action_message},
+                *({"error": f"{number}: {error}"} for number, error in failures),
+            ],
+            table_name="routing_slips",
+            job_name=job_name,
+        )
+        notification.send_notification()
+
+    @classmethod
     def _get_routing_slip_by_status(cls, status: RoutingSlipStatus) -> list[RoutingSlipModel]:
         """Get routing slip by status."""
         return (
@@ -411,7 +520,7 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                     table_name="routing_slips",
                     job_name="Routing Slip Adjustment Job",
                 )
-                notification.send_notification(error_msg)
+                notification.send_notification()
             raise ValueError(error_msg)
 
     @classmethod

--- a/jobs/payment-jobs/tasks/routing_slip_task.py
+++ b/jobs/payment-jobs/tasks/routing_slip_task.py
@@ -64,7 +64,6 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
             # 2. Create receipt to the parent.
             # 3. Change the payment account of child to parent.
             # 4. Change the status.
-            cfs_account = None
             parent_rs = None
             parent_rs_remaining_after_sync_link = None
             try:
@@ -75,7 +74,7 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                 )
 
                 # reverse routing slip receipt
-                if CFSService.get_receipt(cfs_account, routing_slip.number).get("status") != CfsReceiptStatus.REV.value:
+                if not cls._receipt_already_reversed(cfs_account, routing_slip.number):
                     CFSService.reverse_rs_receipt_in_cfs(cfs_account, routing_slip.number, ReverseOperation.LINK.value)
                 cfs_account.status = CfsAccountStatus.INACTIVE.value
 
@@ -159,15 +158,11 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                     payment_account.id, PaymentMethod.INTERNAL.value
                 )
 
-                # Skip if a previous, partially-failed attempt already reversed this receipt in CAS -
-                # reversing an already-reversed receipt is not guaranteed to be safe to retry.
-                if (
-                    CFSService.get_receipt(cfs_account, rs.generate_cas_receipt_number()).get("status")
-                    != CfsReceiptStatus.REV.value
-                ):
+                original_receipt_number = rs.generate_cas_receipt_number()
+                if not cls._receipt_already_reversed(cfs_account, original_receipt_number):
                     CFSService.reverse_rs_receipt_in_cfs(
                         cfs_account,
-                        rs.generate_cas_receipt_number(),
+                        original_receipt_number,
                         ReverseOperation.CORRECTION.value,
                     )
                 # Update the version, which generates a new receipt number. This is to avoid duplicate receipt number.
@@ -197,9 +192,8 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                     f"Error on Processing CORRECTION for :={rs.number}, routing slip : {rs.id}, ERROR : {str(e)}",
                     exc_info=True,
                 )
-                # Note: this only undoes the cas_version_suffix bump. If the original CAS receipt was
-                # already reversed before the failure, that reversal itself can't be undone from here -
-                # it needs the same manual recovery as any other CAS-side failure.
+                # Only the cas_version_suffix bump is undone. A reversal that already went through in
+                # CAS stays reversed - the next run detects that and skips re-reversing it.
                 rollback_ok = True
                 try:
                     rs.cas_version_suffix = cas_version_suffix_snapshot
@@ -255,9 +249,11 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                 child_routing_slips = RoutingSlipModel.find_children(routing_slip.number)
                 for rs in (routing_slip, *child_routing_slips):
                     receipt_number = rs.generate_cas_receipt_number()
-                    CFSService.reverse_rs_receipt_in_cfs(cfs_account, receipt_number, ReverseOperation.VOID.value)
+                    # An earlier attempt may have failed partway through this same group.
+                    if not cls._receipt_already_reversed(cfs_account, receipt_number):
+                        CFSService.reverse_rs_receipt_in_cfs(cfs_account, receipt_number, ReverseOperation.VOID.value)
                     # Track this so a failure partway through the group can report exactly which
-                    # members already had their CAS receipt reversed - those can't be re-reversed.
+                    # members already had their CAS receipt reversed.
                     reversed_numbers.append(rs.number)
                 # Void routing slips aren't supposed to have pending transactions, so no need to look at invoices.
                 cfs_account.status = CfsAccountStatus.INACTIVE.value
@@ -272,9 +268,8 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                     f"routing slip : {routing_slip.id}, ERROR : {str(e)}",
                     exc_info=True,
                 )
-                # Note: this only undoes our own DB-side changes for this attempt. Any receipt that
-                # was already reversed in CAS before the failure can't be undone from here - it needs
-                # the same manual recovery as any other CAS-side failure.
+                # Only our own DB-side changes are undone. Receipts already reversed in CAS stay
+                # reversed - the next run detects that and skips re-reversing them.
                 rollback_ok = True
                 try:
                     if cfs_account is not None:
@@ -288,12 +283,16 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                         f"Rollback failed for Routing Slip number:={routing_slip.number}, ERROR : {str(rollback_error)}",
                         exc_info=True,
                     )
-                all_numbers = [routing_slip.number] + [rs.number for rs in child_routing_slips]
-                not_yet_reversed = [number for number in all_numbers if number not in reversed_numbers]
-                partial_state_note = (
-                    f"Already reversed in CAS: {reversed_numbers or 'none'}; not yet reversed: {not_yet_reversed}."
-                )
-                message = f"{cls._failure_message(e, rollback_ok)} {partial_state_note}"
+                message = cls._failure_message(e, rollback_ok)
+                if reversed_numbers:
+                    # Only worth saying when the group was partly processed - these receipts are
+                    # already reversed in CAS and can't be re-reversed on a retry.
+                    all_numbers = [routing_slip.number] + [rs.number for rs in child_routing_slips]
+                    not_yet_reversed = [number for number in all_numbers if number not in reversed_numbers]
+                    message += (
+                        f" Already reversed in CAS: {', '.join(reversed_numbers)};"
+                        f" not yet reversed: {', '.join(not_yet_reversed) or 'none'}."
+                    )
                 failures.append((routing_slip.number, message))
                 continue
 
@@ -483,6 +482,16 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                 exc_info=True,
             )
             return False
+
+    @staticmethod
+    def _receipt_already_reversed(cfs_account: CfsAccountModel, receipt_number: str) -> bool:
+        """Whether CAS already has this receipt as reversed.
+
+        A partially-failed earlier attempt can leave the receipt reversed in CAS while our own
+        records still look untouched. Reversing an already-reversed receipt isn't guaranteed to be
+        safe, so callers skip that step when this returns True.
+        """
+        return CFSService.get_receipt(cfs_account, receipt_number).get("status") == CfsReceiptStatus.REV.value
 
     @staticmethod
     def _failure_message(error: Exception, rollback_ok: bool) -> str:

--- a/jobs/payment-jobs/tasks/routing_slip_task.py
+++ b/jobs/payment-jobs/tasks/routing_slip_task.py
@@ -235,6 +235,8 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
         failures = []
         for routing_slip in routing_slips:
             cfs_account = None
+            child_routing_slips: list[RoutingSlipModel] = []
+            reversed_numbers: list[str] = []
             remaining_amount_snapshot = routing_slip.remaining_amount
             cas_version_suffix_snapshot = routing_slip.cas_version_suffix
             try:
@@ -250,10 +252,13 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                 )
 
                 # Reverse all child routing slips, as all linked routing slips are also considered as VOID.
-                child_routing_slips: list[RoutingSlipModel] = RoutingSlipModel.find_children(routing_slip.number)
+                child_routing_slips = RoutingSlipModel.find_children(routing_slip.number)
                 for rs in (routing_slip, *child_routing_slips):
                     receipt_number = rs.generate_cas_receipt_number()
                     CFSService.reverse_rs_receipt_in_cfs(cfs_account, receipt_number, ReverseOperation.VOID.value)
+                    # Track this so a failure partway through the group can report exactly which
+                    # members already had their CAS receipt reversed - those can't be re-reversed.
+                    reversed_numbers.append(rs.number)
                 # Void routing slips aren't supposed to have pending transactions, so no need to look at invoices.
                 cfs_account.status = CfsAccountStatus.INACTIVE.value
                 routing_slip.remaining_amount = 0
@@ -283,7 +288,13 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                         f"Rollback failed for Routing Slip number:={routing_slip.number}, ERROR : {str(rollback_error)}",
                         exc_info=True,
                     )
-                failures.append((routing_slip.number, cls._failure_message(e, rollback_ok)))
+                all_numbers = [routing_slip.number] + [rs.number for rs in child_routing_slips]
+                not_yet_reversed = [number for number in all_numbers if number not in reversed_numbers]
+                partial_state_note = (
+                    f"Already reversed in CAS: {reversed_numbers or 'none'}; not yet reversed: {not_yet_reversed}."
+                )
+                message = f"{cls._failure_message(e, rollback_ok)} {partial_state_note}"
+                failures.append((routing_slip.number, message))
                 continue
 
         cls._notify_job_failures(

--- a/jobs/payment-jobs/tasks/routing_slip_task.py
+++ b/jobs/payment-jobs/tasks/routing_slip_task.py
@@ -238,11 +238,8 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                 child_routing_slips = RoutingSlipModel.find_children(routing_slip.number)
                 for rs in (routing_slip, *child_routing_slips):
                     receipt_number = rs.generate_cas_receipt_number()
-                    # An earlier attempt may have failed partway through this same group.
                     if not cls._receipt_already_reversed(cfs_account, receipt_number):
                         CFSService.reverse_rs_receipt_in_cfs(cfs_account, receipt_number, ReverseOperation.VOID.value)
-                    # Track this so a failure partway through the group can report exactly which
-                    # members already had their CAS receipt reversed.
                     reversed_numbers.append(rs.number)
                 # Void routing slips aren't supposed to have pending transactions, so no need to look at invoices.
                 cfs_account.status = CfsAccountStatus.INACTIVE.value
@@ -455,11 +452,7 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
 
     @classmethod
     def _rollback_failed_correction(cls, routing_slip: RoutingSlipModel, cas_version_suffix: int) -> bool:
-        """Undo the version bump from a failed correction. See _rollback_failed_link for the pattern.
-
-        A reversal that already went through in CAS stays reversed - the next run detects that and
-        skips re-reversing it.
-        """
+        """Undo the version bump from a failed correction. See _rollback_failed_link for the pattern."""
         try:
             routing_slip.cas_version_suffix = cas_version_suffix
             routing_slip.save()
@@ -479,11 +472,7 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
         remaining_amount: Decimal,
         cas_version_suffix: int,
     ) -> bool:
-        """Undo our own changes from a failed void. See _rollback_failed_link for the pattern.
-
-        Receipts already reversed in CAS stay reversed - the next run detects that and skips
-        re-reversing them.
-        """
+        """Undo our own changes from a failed void. See _rollback_failed_link for the pattern."""
         try:
             if cfs_account is not None:
                 cfs_account.status = CfsAccountStatus.ACTIVE.value

--- a/jobs/payment-jobs/tasks/routing_slip_task.py
+++ b/jobs/payment-jobs/tasks/routing_slip_task.py
@@ -66,7 +66,7 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
             # 4. Change the status.
             cfs_account = None
             parent_rs = None
-            parent_rs_remaining_snapshot = None
+            parent_rs_remaining_after_sync_link = None
             try:
                 current_app.logger.debug(f"Linking Routing Slip: {routing_slip.number}")
                 payment_account: PaymentAccountModel = PaymentAccountModel.find_by_id(routing_slip.payment_account_id)
@@ -81,7 +81,7 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
 
                 # apply receipt to parent cfs account
                 parent_rs = RoutingSlipModel.find_by_number(routing_slip.parent_number)
-                parent_rs_remaining_snapshot = parent_rs.remaining_amount
+                parent_rs_remaining_after_sync_link = parent_rs.remaining_amount
                 parent_payment_account: PaymentAccountModel = PaymentAccountModel.find_by_id(
                     parent_rs.payment_account_id
                 )
@@ -119,8 +119,8 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                     f"routing slip : {routing_slip.id}, ERROR : {str(e)}",
                     exc_info=True,
                 )
-                cls._rollback_failed_link(routing_slip, parent_rs, parent_rs_remaining_snapshot)
-                failures.append((routing_slip.number, str(e)))
+                rollback_ok = cls._rollback_failed_link(routing_slip, parent_rs, parent_rs_remaining_after_sync_link)
+                failures.append((routing_slip.number, cls._failure_message(e, rollback_ok)))
                 continue
 
         cls._notify_job_failures(
@@ -159,11 +159,17 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                     payment_account.id, PaymentMethod.INTERNAL.value
                 )
 
-                CFSService.reverse_rs_receipt_in_cfs(
-                    cfs_account,
-                    rs.generate_cas_receipt_number(),
-                    ReverseOperation.CORRECTION.value,
-                )
+                # Skip if a previous, partially-failed attempt already reversed this receipt in CAS -
+                # reversing an already-reversed receipt is not guaranteed to be safe to retry.
+                if (
+                    CFSService.get_receipt(cfs_account, rs.generate_cas_receipt_number()).get("status")
+                    != CfsReceiptStatus.REV.value
+                ):
+                    CFSService.reverse_rs_receipt_in_cfs(
+                        cfs_account,
+                        rs.generate_cas_receipt_number(),
+                        ReverseOperation.CORRECTION.value,
+                    )
                 # Update the version, which generates a new receipt number. This is to avoid duplicate receipt number.
                 rs.cas_version_suffix += 1
                 # Recreate the receipt with the modified total.
@@ -194,9 +200,17 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                 # Note: this only undoes the cas_version_suffix bump. If the original CAS receipt was
                 # already reversed before the failure, that reversal itself can't be undone from here -
                 # it needs the same manual recovery as any other CAS-side failure.
-                rs.cas_version_suffix = cas_version_suffix_snapshot
-                rs.save()
-                failures.append((rs.number, str(e)))
+                rollback_ok = True
+                try:
+                    rs.cas_version_suffix = cas_version_suffix_snapshot
+                    rs.save()
+                except Exception as rollback_error:  # NOQA # pylint: disable=broad-except
+                    rollback_ok = False
+                    current_app.logger.error(
+                        f"Rollback failed for Routing Slip number:={rs.number}, ERROR : {str(rollback_error)}",
+                        exc_info=True,
+                    )
+                failures.append((rs.number, cls._failure_message(e, rollback_ok)))
                 continue
 
         cls._notify_job_failures(
@@ -256,12 +270,20 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
                 # Note: this only undoes our own DB-side changes for this attempt. Any receipt that
                 # was already reversed in CAS before the failure can't be undone from here - it needs
                 # the same manual recovery as any other CAS-side failure.
-                if cfs_account is not None:
-                    cfs_account.status = CfsAccountStatus.ACTIVE.value
-                routing_slip.remaining_amount = remaining_amount_snapshot
-                routing_slip.cas_version_suffix = cas_version_suffix_snapshot
-                routing_slip.save()
-                failures.append((routing_slip.number, str(e)))
+                rollback_ok = True
+                try:
+                    if cfs_account is not None:
+                        cfs_account.status = CfsAccountStatus.ACTIVE.value
+                    routing_slip.remaining_amount = remaining_amount_snapshot
+                    routing_slip.cas_version_suffix = cas_version_suffix_snapshot
+                    routing_slip.save()
+                except Exception as rollback_error:  # NOQA # pylint: disable=broad-except
+                    rollback_ok = False
+                    current_app.logger.error(
+                        f"Rollback failed for Routing Slip number:={routing_slip.number}, ERROR : {str(rollback_error)}",
+                        exc_info=True,
+                    )
+                failures.append((routing_slip.number, cls._failure_message(e, rollback_ok)))
                 continue
 
         cls._notify_job_failures(
@@ -417,8 +439,8 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
         cls,
         routing_slip: RoutingSlipModel,
         parent_rs: RoutingSlipModel,
-        parent_rs_remaining_snapshot: Decimal,
-    ) -> None:
+        parent_rs_remaining_after_sync_link: Decimal,
+    ) -> bool:
         """Undo the do_link changes so a failed link doesn't leave a half-migrated routing slip.
 
         - db.session.rollback() (called by the caller before this) only undoes changes made during
@@ -429,22 +451,34 @@ class RoutingSlipTask:  # pylint:disable=too-few-public-methods
           reversed before the failure. HOLD blocks any spend either way, so it's safe regardless.
           ACTIVE would be wrong if the receipt is gone and the balance isn't backed by anything in CAS.
         - cfs_account is left as-is for the same reason.
-        - A person must check the real CAS state (see the routing slip unlink runbook) before moving
-          this back to ACTIVE.
+        - A person must check the real CAS receipt state for this routing slip before moving it back
+          to ACTIVE.
+
+        Returns False if the rollback itself failed - the caller should treat that as more urgent
+        than a routine CAS failure, since the routing slip's state is then unknown, not just on HOLD.
         """
         try:
-            if parent_rs is not None and parent_rs_remaining_snapshot is not None:
-                parent_rs.remaining_amount = parent_rs_remaining_snapshot - routing_slip.total
+            if parent_rs is not None and parent_rs_remaining_after_sync_link is not None:
+                parent_rs.remaining_amount = parent_rs_remaining_after_sync_link - routing_slip.total
                 parent_rs.save()
             routing_slip.status = RoutingSlipStatus.HOLD.value
             routing_slip.parent_number = None
             routing_slip.remaining_amount = routing_slip.total
             routing_slip.save()
+            return True
         except Exception as rollback_error:  # NOQA # pylint: disable=broad-except
             current_app.logger.error(
                 f"Rollback failed for Routing Slip number:={routing_slip.number}, ERROR : {str(rollback_error)}",
                 exc_info=True,
             )
+            return False
+
+    @staticmethod
+    def _failure_message(error: Exception, rollback_ok: bool) -> str:
+        """Build the failure message, flagging when the rollback itself failed as more urgent."""
+        if rollback_ok:
+            return str(error)
+        return f"URGENT - rollback also failed, routing slip state is unknown. Original error: {error}"
 
     @classmethod
     def _notify_job_failures(cls, failures: list[tuple[str, str]], subject: str, file_name: str, job_name: str) -> None:

--- a/jobs/payment-jobs/tests/jobs/test_routing_slip_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_routing_slip_task.py
@@ -256,16 +256,18 @@ def test_process_void(session):
     parent_rs.status = RoutingSlipStatus.VOID.value
     parent_rs.save()
 
-    with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs") as mock_cfs_reverse:
-        RoutingSlipTask.process_void()
-        mock_cfs_reverse.assert_called()
+    with patch.object(CFSService, "get_receipt", return_value={}):
+        with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs") as mock_cfs_reverse:
+            RoutingSlipTask.process_void()
+            mock_cfs_reverse.assert_called()
 
     # Assert the records.
     assert float(RoutingSlipModel.find_by_number(parent_rs.number).remaining_amount) == 0
 
-    with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs") as mock_cfs_reverse_2:
-        RoutingSlipTask.process_void()
-        mock_cfs_reverse_2.assert_not_called()
+    with patch.object(CFSService, "get_receipt", return_value={}):
+        with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs") as mock_cfs_reverse_2:
+            RoutingSlipTask.process_void()
+            mock_cfs_reverse_2.assert_not_called()
 
 
 def test_process_void_rollback_on_cas_failure(session):
@@ -279,10 +281,11 @@ def test_process_void_rollback_on_cas_failure(session):
     payment_account: PaymentAccountModel = PaymentAccountModel.find_by_id(rs.payment_account_id)
     cfs_account = CfsAccountModel.find_effective_by_payment_method(payment_account.id, PaymentMethod.INTERNAL.value)
 
-    with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs", side_effect=Exception("cas is down")):
-        with patch("tasks.routing_slip_task.JobFailureNotification") as mock_notification:
-            RoutingSlipTask.process_void()
-            mock_notification.return_value.send_notification.assert_called_once()
+    with patch.object(CFSService, "get_receipt", return_value={}):
+        with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs", side_effect=Exception("cas is down")):
+            with patch("tasks.routing_slip_task.JobFailureNotification") as mock_notification:
+                RoutingSlipTask.process_void()
+                mock_notification.return_value.send_notification.assert_called_once()
 
     rs = RoutingSlipModel.find_by_number(number)
     cfs_account = CfsAccountModel.find_by_id(cfs_account.id)
@@ -306,17 +309,18 @@ def test_process_void_reports_partial_reversal(session):
     parent_rs.save()
 
     # First call (the parent itself) succeeds, second call (the child) fails.
-    with patch(
-        "pay_api.services.CFSService.reverse_rs_receipt_in_cfs",
-        side_effect=[None, Exception("cas is down")],
-    ):
-        with patch("tasks.routing_slip_task.JobFailureNotification") as mock_notification:
-            RoutingSlipTask.process_void()
-            error_messages = mock_notification.call_args.kwargs["error_messages"]
-            combined = " ".join(m["error"] for m in error_messages)
-            assert parent_number in combined
-            assert child_number in combined
-            assert "Already reversed in CAS" in combined
+    with patch.object(CFSService, "get_receipt", return_value={}):
+        with patch(
+            "pay_api.services.CFSService.reverse_rs_receipt_in_cfs",
+            side_effect=[None, Exception("cas is down")],
+        ):
+            with patch("tasks.routing_slip_task.JobFailureNotification") as mock_notification:
+                RoutingSlipTask.process_void()
+                error_messages = mock_notification.call_args.kwargs["error_messages"]
+                combined = " ".join(m["error"] for m in error_messages)
+                assert parent_number in combined
+                assert child_number in combined
+                assert "Already reversed in CAS" in combined
 
 
 def test_process_correction(session):

--- a/jobs/payment-jobs/tests/jobs/test_routing_slip_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_routing_slip_task.py
@@ -291,6 +291,34 @@ def test_process_void_rollback_on_cas_failure(session):
     assert rs.cas_version_suffix == 1
 
 
+def test_process_void_reports_partial_reversal(session):
+    """If one member of a parent+children VOID group reverses and another fails, say exactly which."""
+    parent_number = "333333333"
+    child_number = "333333334"
+    factory_routing_slip_account(number=parent_number, status=CfsAccountStatus.ACTIVE.value, total=10)
+    factory_routing_slip_account(number=child_number, status=CfsAccountStatus.ACTIVE.value, total=10)
+    parent_rs = RoutingSlipModel.find_by_number(parent_number)
+    child_rs = RoutingSlipModel.find_by_number(child_number)
+    child_rs.status = RoutingSlipStatus.LINKED.value
+    child_rs.parent_number = parent_rs.number
+    child_rs.save()
+    parent_rs.status = RoutingSlipStatus.VOID.value
+    parent_rs.save()
+
+    # First call (the parent itself) succeeds, second call (the child) fails.
+    with patch(
+        "pay_api.services.CFSService.reverse_rs_receipt_in_cfs",
+        side_effect=[None, Exception("cas is down")],
+    ):
+        with patch("tasks.routing_slip_task.JobFailureNotification") as mock_notification:
+            RoutingSlipTask.process_void()
+            error_messages = mock_notification.call_args.kwargs["error_messages"]
+            combined = " ".join(m["error"] for m in error_messages)
+            assert parent_number in combined
+            assert child_number in combined
+            assert "Already reversed in CAS" in combined
+
+
 def test_process_correction(session):
     """Test Routing slip set to CORRECTION."""
     number = "1111111"

--- a/jobs/payment-jobs/tests/jobs/test_routing_slip_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_routing_slip_task.py
@@ -90,6 +90,43 @@ def test_link_rs(session):
             mock_create_cfs.assert_not_called()
 
 
+def test_link_rs_rollback_on_cas_failure(session):
+    """A failed link should roll the child back to HOLD, restore the parent's balance, and notify once."""
+    child_rs_number = "1234"
+    parent_rs_number = "89799"
+    child_total = 100
+    parent_total = 50
+    factory_routing_slip_account(
+        number=child_rs_number, status=CfsAccountStatus.ACTIVE.value, total=child_total, remaining_amount=0
+    )
+    factory_routing_slip_account(
+        number=parent_rs_number,
+        status=CfsAccountStatus.ACTIVE.value,
+        total=parent_total,
+        # Simulates do_link having already transferred the child's balance onto the parent.
+        remaining_amount=parent_total + child_total,
+    )
+    child_rs = RoutingSlipModel.find_by_number(child_rs_number)
+    parent_rs = RoutingSlipModel.find_by_number(parent_rs_number)
+    child_rs.status = RoutingSlipStatus.LINKED.value
+    child_rs.parent_number = parent_rs.number
+    child_rs.save()
+
+    with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs"):
+        with patch.object(CFSService, "get_receipt", return_value={"status": "REV"}):
+            with patch("pay_api.services.CFSService.create_cfs_receipt", side_effect=Exception("cas is down")):
+                with patch("tasks.routing_slip_task.JobFailureNotification") as mock_notification:
+                    RoutingSlipTask.link_routing_slips()
+                    mock_notification.return_value.send_notification.assert_called_once()
+
+    child_rs = RoutingSlipModel.find_by_number(child_rs_number)
+    parent_rs = RoutingSlipModel.find_by_number(parent_rs_number)
+    assert child_rs.status == RoutingSlipStatus.HOLD.value
+    assert child_rs.parent_number is None
+    assert float(child_rs.remaining_amount) == child_total
+    assert float(parent_rs.remaining_amount) == parent_total
+
+
 def test_process_nsf(session):
     """Test process NSF."""
     # 1. Link 2 child routing slips with parent.
@@ -202,6 +239,29 @@ def test_process_void(session):
         mock_cfs_reverse_2.assert_not_called()
 
 
+def test_process_void_rollback_on_cas_failure(session):
+    """A failed void should restore cfs_account status, remaining_amount and cas_version_suffix, and notify once."""
+    number = "222222222"
+    factory_routing_slip_account(number=number, status=CfsAccountStatus.ACTIVE.value, total=10, remaining_amount=10)
+    rs = RoutingSlipModel.find_by_number(number)
+    rs.status = RoutingSlipStatus.VOID.value
+    rs.save()
+
+    payment_account: PaymentAccountModel = PaymentAccountModel.find_by_id(rs.payment_account_id)
+    cfs_account = CfsAccountModel.find_effective_by_payment_method(payment_account.id, PaymentMethod.INTERNAL.value)
+
+    with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs", side_effect=Exception("cas is down")):
+        with patch("tasks.routing_slip_task.JobFailureNotification") as mock_notification:
+            RoutingSlipTask.process_void()
+            mock_notification.return_value.send_notification.assert_called_once()
+
+    rs = RoutingSlipModel.find_by_number(number)
+    cfs_account = CfsAccountModel.find_by_id(cfs_account.id)
+    assert cfs_account.status == CfsAccountStatus.ACTIVE.value
+    assert float(rs.remaining_amount) == 10
+    assert rs.cas_version_suffix == 1
+
+
 def test_process_correction(session):
     """Test Routing slip set to CORRECTION."""
     number = "1111111"
@@ -244,6 +304,25 @@ def test_process_correction(session):
 
     assert rs.status == RoutingSlipStatus.COMPLETE.value
     assert rs.cas_version_suffix == 2
+
+
+def test_process_correction_rollback_on_cas_failure(session):
+    """A failed correction should restore cas_version_suffix and notify once."""
+    number = "1111112"
+    factory_routing_slip_account(number=number, status=CfsAccountStatus.ACTIVE.value, total=900)
+    rs = RoutingSlipModel.find_by_number(number)
+    rs.status = RoutingSlipStatus.CORRECTION.value
+    rs.save()
+
+    with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs"):
+        with patch("pay_api.services.CFSService.create_cfs_receipt", side_effect=Exception("cas is down")):
+            with patch("tasks.routing_slip_task.JobFailureNotification") as mock_notification:
+                RoutingSlipTask.process_correction()
+                mock_notification.return_value.send_notification.assert_called_once()
+
+    rs = RoutingSlipModel.find_by_number(number)
+    assert rs.status == RoutingSlipStatus.CORRECTION.value
+    assert rs.cas_version_suffix == 1
 
 
 def test_link_to_nsf_rs(session):

--- a/jobs/payment-jobs/tests/jobs/test_routing_slip_task.py
+++ b/jobs/payment-jobs/tests/jobs/test_routing_slip_task.py
@@ -127,6 +127,35 @@ def test_link_rs_rollback_on_cas_failure(session):
     assert float(parent_rs.remaining_amount) == parent_total
 
 
+def test_link_rs_escalates_when_rollback_itself_fails(session):
+    """If the rollback itself throws, the notification must call that out as more urgent."""
+    child_rs_number = "1235"
+    parent_rs_number = "89800"
+    factory_routing_slip_account(
+        number=child_rs_number, status=CfsAccountStatus.ACTIVE.value, total=100, remaining_amount=0
+    )
+    factory_routing_slip_account(
+        number=parent_rs_number, status=CfsAccountStatus.ACTIVE.value, total=50, remaining_amount=150
+    )
+    child_rs = RoutingSlipModel.find_by_number(child_rs_number)
+    parent_rs = RoutingSlipModel.find_by_number(parent_rs_number)
+    child_rs.status = RoutingSlipStatus.LINKED.value
+    child_rs.parent_number = parent_rs.number
+    child_rs.save()
+
+    # Make the rollback's own save() blow up, simulating the rollback itself failing.
+    parent_rs.save = MagicMock(side_effect=Exception("db down"))
+    with patch("tasks.routing_slip_task.RoutingSlipModel.find_by_number", return_value=parent_rs):
+        with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs"):
+            with patch.object(CFSService, "get_receipt", return_value={"status": "REV"}):
+                with patch("pay_api.services.CFSService.create_cfs_receipt", side_effect=Exception("cas is down")):
+                    with patch("tasks.routing_slip_task.JobFailureNotification") as mock_notification:
+                        RoutingSlipTask.link_routing_slips()
+                        mock_notification.return_value.send_notification.assert_called_once()
+                        error_messages = mock_notification.call_args.kwargs["error_messages"]
+                        assert any("URGENT" in m["error"] for m in error_messages)
+
+
 def test_process_nsf(session):
     """Test process NSF."""
     # 1. Link 2 child routing slips with parent.
@@ -294,13 +323,14 @@ def test_process_correction(session):
 
     session.commit()
 
-    with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs") as mock_reverse:
-        with patch("pay_api.services.CFSService.create_cfs_receipt") as mock_create_receipt:
-            with patch("pay_api.services.CFSService.get_invoice") as mock_get_invoice:
-                RoutingSlipTask.process_correction()
-                mock_reverse.assert_called()
-                mock_get_invoice.assert_called()
-                mock_create_receipt.assert_called()
+    with patch.object(CFSService, "get_receipt", return_value={"status": "CLEARED"}):
+        with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs") as mock_reverse:
+            with patch("pay_api.services.CFSService.create_cfs_receipt") as mock_create_receipt:
+                with patch("pay_api.services.CFSService.get_invoice") as mock_get_invoice:
+                    RoutingSlipTask.process_correction()
+                    mock_reverse.assert_called()
+                    mock_get_invoice.assert_called()
+                    mock_create_receipt.assert_called()
 
     assert rs.status == RoutingSlipStatus.COMPLETE.value
     assert rs.cas_version_suffix == 2
@@ -314,15 +344,32 @@ def test_process_correction_rollback_on_cas_failure(session):
     rs.status = RoutingSlipStatus.CORRECTION.value
     rs.save()
 
-    with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs"):
-        with patch("pay_api.services.CFSService.create_cfs_receipt", side_effect=Exception("cas is down")):
-            with patch("tasks.routing_slip_task.JobFailureNotification") as mock_notification:
-                RoutingSlipTask.process_correction()
-                mock_notification.return_value.send_notification.assert_called_once()
+    with patch.object(CFSService, "get_receipt", return_value={"status": "CLEARED"}):
+        with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs"):
+            with patch("pay_api.services.CFSService.create_cfs_receipt", side_effect=Exception("cas is down")):
+                with patch("tasks.routing_slip_task.JobFailureNotification") as mock_notification:
+                    RoutingSlipTask.process_correction()
+                    mock_notification.return_value.send_notification.assert_called_once()
 
     rs = RoutingSlipModel.find_by_number(number)
     assert rs.status == RoutingSlipStatus.CORRECTION.value
     assert rs.cas_version_suffix == 1
+
+
+def test_process_correction_skips_reverse_if_already_reversed(session):
+    """A retry after a partial failure shouldn't reverse a receipt that's already REV in CAS."""
+    number = "1111113"
+    factory_routing_slip_account(number=number, status=CfsAccountStatus.ACTIVE.value, total=900)
+    rs = RoutingSlipModel.find_by_number(number)
+    rs.status = RoutingSlipStatus.CORRECTION.value
+    rs.save()
+
+    with patch.object(CFSService, "get_receipt", return_value={"status": "REV"}):
+        with patch("pay_api.services.CFSService.reverse_rs_receipt_in_cfs") as mock_reverse:
+            with patch("pay_api.services.CFSService.create_cfs_receipt"):
+                with patch("pay_api.services.CFSService.get_invoice"):
+                    RoutingSlipTask.process_correction()
+                    mock_reverse.assert_not_called()
 
 
 def test_link_to_nsf_rs(session):


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/34628

*Description of changes:*
Synchronous API
       ↓
PAYDB committed
       ↓
Async routing-slip job
       ↓
CAS operation
       ↓
      FAIL
       ↓
PAYDB rollback / compensation
       ↓
HOLD
       ↓
Notification
       ↓
Dev verifies CAS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
