### PR TITLE
fix(pay-api): strip leftover wildcard CORS header on error responses

### DIFF
--- a/pay-api/src/pay_api/__init__.py
+++ b/pay-api/src/pay_api/__init__.py
@@ -103,6 +103,13 @@ def setup_response_headers(app):
         if origin and origin in app.config.get("CORS_ORIGINS", []):
             response.headers["Access-Control-Allow-Origin"] = origin
             response.headers["Vary"] = "Origin"
+        elif response.headers.get("Access-Control-Allow-Origin") == "*":
+            # sbc_common_components.ExceptionHandler sets a wildcard unconditionally on
+            # error responses (401/404/etc.) before this hook runs. Strip it here so it
+            # never survives for a non-matching or missing Origin. Only ever removes a
+            # literal "*" -- never touches a real domain value flask-cors itself may have
+            # set on a decorated route's own preflight handling.
+            del response.headers["Access-Control-Allow-Origin"]
         response.headers["Access-Control-Allow-Headers"] = (
             "Authorization, Content-Type, registries-trace-id, Account-Id, App-Name, x-apikey, Original-Username, "
             "Original-Sub"

--- a/pay-api/tests/unit/api/test_cors_error_path_e2e.py
+++ b/pay-api/tests/unit/api/test_cors_error_path_e2e.py
@@ -1,0 +1,47 @@
+"""Tests to verify CORS headers on error responses.
+
+sbc_common_components.ExceptionHandler sets a wildcard Access-Control-Allow-Origin
+unconditionally on error responses (401/404/etc.) before pay-api's own after_request
+hook runs. Ensure that wildcard never survives for a non-matching or missing Origin.
+"""
+
+import pytest
+
+REAL_ORIGIN = "https://dev.pay.bcregistry.gov.bc.ca"
+
+
+@pytest.fixture
+def cors_origins_override(app):
+    """Scope a CORS_ORIGINS override to this file, restoring it after each test."""
+    original = app.config.get("CORS_ORIGINS")
+    app.config["CORS_ORIGINS"] = [REAL_ORIGIN]
+    yield
+    app.config["CORS_ORIGINS"] = original
+
+
+def test_malicious_origin_gets_no_header_on_401(app, client, jwt, session, cors_origins_override):
+    """Assert a non-matching origin gets no CORS header on a 401 response."""
+    rv = client.get("/api/v1/fees/BC/BCINC", headers={"Origin": "https://evil-attacker-site.ru"})
+    assert rv.status_code == 401
+    assert "Access-Control-Allow-Origin" not in rv.headers
+
+
+def test_no_origin_gets_no_header_on_401(app, client, jwt, session, cors_origins_override):
+    """Assert a missing origin gets no CORS header on a 401 response."""
+    rv = client.get("/api/v1/fees/BC/BCINC")
+    assert rv.status_code == 401
+    assert "Access-Control-Allow-Origin" not in rv.headers
+
+
+def test_malicious_origin_gets_no_header_on_404(app, client, jwt, session, cors_origins_override):
+    """Assert a non-matching origin gets no CORS header on a 404 response."""
+    rv = client.get("/api/v1/this-route-does-not-exist", headers={"Origin": "https://evil-attacker-site.ru"})
+    assert rv.status_code == 404
+    assert "Access-Control-Allow-Origin" not in rv.headers
+
+
+def test_real_origin_still_gets_correct_header_on_401(app, client, jwt, session, cors_origins_override):
+    """Assert a matching origin still gets echoed back correctly on a 401 response."""
+    rv = client.get("/api/v1/fees/BC/BCINC", headers={"Origin": REAL_ORIGIN})
+    assert rv.status_code == 401
+    assert rv.headers.get("Access-Control-Allow-Origin") == REAL_ORIGIN


### PR DESCRIPTION
## Summary

Found during thorough live testing of the dev deploy of #2612 (not caught by the original unit tests): `sbc_common_components.ExceptionHandler` — registered separately in pay-api's own `__init__.py` via `ExceptionHandler(app)`, right after the CORS setup — sets `Access-Control-Allow-Origin: *` unconditionally on **every error response**: auth failures (401), not-found (404), DB errors, unhandled exceptions, and every standard HTTP error code Werkzeug knows about.

Pay-API's own `after_request` hook from #2612 only *overwrote* that header when the request's `Origin` matched the configured allow-list — it never touched the header otherwise, so the wildcard set by `ExceptionHandler` survived completely untouched whenever the origin was missing or didn't match. Concretely: **a malicious origin could still read any error response** (401/404/etc.) after #2612, even though successful (2xx) responses were correctly locked down.

Verified live against the actual deployed dev service:
```
curl -i -H "Origin: https://evil-attacker-site.ru" https://pay-api-dev-.../api/v1/fees/BC/BCINC
# before this fix: HTTP/1.1 401 Unauthorized / access-control-allow-origin: *
```

## Fix

`pay_api/__init__.py`'s `handle_after_request` now also strips the header when it's currently a literal `"*"` and the request's Origin doesn't match the allow-list:

```python
elif response.headers.get("Access-Control-Allow-Origin") == "*":
    del response.headers["Access-Control-Allow-Origin"]
```

Deliberately narrow — only ever removes a literal `"*"`, never a real domain value. This matters because flask-cors's own decorator-level preflight handling (`@cross_origin()` on each route) legitimately returns a real configured origin even without a request `Origin` header present (its `always_send` behavior) — a blanket "clear on non-match" first attempt broke that and failed 19 of the existing preflight tests. This version doesn't touch that path at all; it only targets the specific wildcard signature that `ExceptionHandler` sets.

## Test plan

- [x] New `tests/unit/api/test_cors_error_path_e2e.py`: malicious/missing origin gets no header on 401 and 404; matching origin still gets echoed correctly on 401
- [x] Full `test_cors_preflight.py` + new tests run together: 24/24 passing, against a real running app + real Postgres
- [x] `ruff format --check` / `ruff check` clean
- [x] Live-verified the fix resolves the exact gap found (see Summary) — will re-verify against dev again after this deploys

Targets `feature-harden-cors` (same testing branch as #2612) so it can go through the same dev-deploy-and-verify cycle before eventually landing on `main` together.