### PR TITLE
34417 - account link auth check for invoice / receipt

### DIFF
--- a/pay-api/src/pay_api/resources/v1/invoice.py
+++ b/pay-api/src/pay_api/resources/v1/invoice.py
@@ -70,6 +70,7 @@ def post_invoice():
         business_identifier=business_identifier,
         corp_type_code=corp_type_code,
         contains_role=MAKE_PAYMENT,
+        allow_linking_key=True,
     )
     try:
         response, status = (
@@ -89,7 +90,7 @@ def get_invoice(invoice_id):
     """Get the invoice records."""
     try:
         response, status = (
-            InvoiceService.find_by_id(invoice_id).asdict(include_dynamic_fields=True),
+            InvoiceService.find_by_id(invoice_id, allow_linking_key=True).asdict(include_dynamic_fields=True),
             HTTPStatus.OK,
         )
     except BusinessException as exception:

--- a/pay-api/src/pay_api/resources/v1/invoices.py
+++ b/pay-api/src/pay_api/resources/v1/invoices.py
@@ -38,7 +38,7 @@ def get_invoice_by_id(invoice_id):
     try:
         response = {"items": []}
 
-        response["items"].append(InvoiceService.find_by_id(invoice_id).asdict())
+        response["items"].append(InvoiceService.find_by_id(invoice_id, allow_linking_key=True).asdict())
     except BusinessException as exception:
         return exception.response()
     return jsonify(response), HTTPStatus.OK

--- a/pay-api/src/pay_api/services/auth.py
+++ b/pay-api/src/pay_api/services/auth.py
@@ -37,6 +37,7 @@ def check_auth(
     business_identifier: str,
     account_id: str = None,
     corp_type_code: str = None,
+    allow_linking_key: bool = False,
     **kwargs,
 ):  # pylint: disable=unused-argument, too-many-branches, too-many-statements
     """Authorize the user for the business entity and return authorization response."""
@@ -89,7 +90,9 @@ def check_auth(
                 current_app.config.get("AUTH_API_ENDPOINT")
                 + f"entities/{business_identifier}/authorizations?expanded=true"
             )
-            additional_headers = {"Account-Linking-Key": user.linking_key} if user.linking_key else None
+            additional_headers = (
+                {"Account-Linking-Key": user.linking_key} if allow_linking_key and user.linking_key else None
+            )
             auth_response = (
                 RestService.get(
                     auth_url,

--- a/pay-api/src/pay_api/services/invoice.py
+++ b/pay-api/src/pay_api/services/invoice.py
@@ -408,7 +408,12 @@ class Invoice:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         return invoice
 
     @staticmethod
-    def find_by_id(identifier: int, skip_auth_check: bool = False, one_of_roles=ALL_ALLOWED_ROLES):
+    def find_by_id(
+        identifier: int,
+        skip_auth_check: bool = False,
+        one_of_roles=ALL_ALLOWED_ROLES,
+        allow_linking_key: bool = False,
+    ):
         """Find invoice by id."""
         invoice_dao = InvoiceModel.find_by_id(identifier)
 
@@ -416,7 +421,7 @@ class Invoice:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             raise BusinessException(Error.INVALID_INVOICE_ID)
 
         if not skip_auth_check:
-            Invoice._check_for_auth(invoice_dao, one_of_roles)
+            Invoice._check_for_auth(invoice_dao, one_of_roles, allow_linking_key=allow_linking_key)
 
         invoice = Invoice()
         invoice._dao = invoice_dao  # pylint: disable=protected-access
@@ -509,7 +514,7 @@ class Invoice:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not invoice_dao:
             raise BusinessException(Error.INVALID_INVOICE_ID)
 
-        Invoice._check_for_auth(invoice_dao)
+        Invoice._check_for_auth(invoice_dao, allow_linking_key=True)
 
         payment_account: PaymentAccountModel = PaymentAccountModel.find_by_id(invoice_dao.payment_account_id)
         cfs_account = CfsAccountModel.find_by_id(invoice_dao.cfs_account_id)
@@ -596,11 +601,11 @@ class Invoice:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @staticmethod
     @user_context
-    def _check_for_auth(dao, one_of_roles=ALL_ALLOWED_ROLES, **kwargs):
+    def _check_for_auth(dao, one_of_roles=ALL_ALLOWED_ROLES, allow_linking_key: bool = False, **kwargs):
         user: UserContext = kwargs["user"]
         # Check auth by business identifier if account linking key is also present.
-        if user.linking_key and dao.business_identifier:
-            check_auth(dao.business_identifier, one_of_roles=one_of_roles)
+        if allow_linking_key and user.linking_key and dao.business_identifier:
+            check_auth(dao.business_identifier, one_of_roles=one_of_roles, allow_linking_key=True)
             return
         account_id = dao.payment_account.auth_account_id if dao.payment_account else None
         if user.is_system():

--- a/pay-api/src/pay_api/services/invoice.py
+++ b/pay-api/src/pay_api/services/invoice.py
@@ -598,6 +598,10 @@ class Invoice:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     @user_context
     def _check_for_auth(dao, one_of_roles=ALL_ALLOWED_ROLES, **kwargs):
         user: UserContext = kwargs["user"]
+        # Check auth by business identifier if account linking key is also present.
+        if user.linking_key and dao.business_identifier:
+            check_auth(dao.business_identifier, one_of_roles=one_of_roles)
+            return
         account_id = dao.payment_account.auth_account_id if dao.payment_account else None
         if user.is_system():
             account_id = None

--- a/pay-api/src/pay_api/services/receipt.py
+++ b/pay-api/src/pay_api/services/receipt.py
@@ -106,7 +106,9 @@ class Receipt:  # pylint: disable=too-many-instance-attributes
             if has_product_role:
                 invoice_data = Invoice.find_product_invoice_id(invoice_identifier, products)
             else:
-                invoice_data = Invoice.find_by_id(invoice_identifier, skip_auth_check=skip_auth_check)
+                invoice_data = Invoice.find_by_id(
+                    invoice_identifier, skip_auth_check=skip_auth_check, allow_linking_key=True
+                )
 
         is_pending_invoice = (
             invoice_data.payment_method_code

--- a/pay-api/src/pay_api/version.py
+++ b/pay-api/src/pay_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = "1.26.0"  # pylint: disable=invalid-name
+__version__ = "1.27.0"  # pylint: disable=invalid-name

--- a/pay-api/tests/conftest.py
+++ b/pay-api/tests/conftest.py
@@ -177,7 +177,7 @@ def linking_key_auth_mock():
             payment_account_id = vendor_account_id if "Account-Linking-Key" in additional_headers else source_account_id
             mock_response = MagicMock()
             mock_response.json.return_value = {
-                "roles": roles or ["edit", "view", "make_payment"],
+                "roles": ["edit", "view", "make_payment"] if roles is None else roles,
                 "account": {"id": source_account_id, "paymentAccountId": payment_account_id},
             }
             return mock_response

--- a/pay-api/tests/unit/api/test_payment_request.py
+++ b/pay-api/tests/unit/api/test_payment_request.py
@@ -1958,3 +1958,61 @@ def test_payment_request_creation_account_id_ignores_linking_key(session, client
     invoice = InvoiceModel.find_by_id(rv.json.get("id"))
     payment_account = PaymentAccountModel.find_by_id(invoice.payment_account_id)
     assert payment_account.auth_account_id == source_account_id
+
+
+def test_get_invoice_linking_key_allows_business_filing_access(session, client, jwt, app, linking_key_auth_mock):
+    """Assert a linking-key holder can fetch a business-filing invoice they don't directly own.
+
+    _check_for_auth routes to check_auth without an account_id (business_identifier only) when a
+    linking key is present and the invoice has a business_identifier.
+    """
+    vendor_account = factory_payment_account(auth_account_id="VENDOR_777")
+    vendor_account.save()
+    invoice = factory_invoice(payment_account=vendor_account, business_identifier="CP0001234")
+    invoice.save()
+
+    token = jwt.create_jwt(get_claims(), token_header)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "content-type": "application/json",
+        "Account-Linking-Key": "test-linking-key",
+    }
+
+    with patch(
+        "pay_api.services.auth.RestService.get",
+        side_effect=linking_key_auth_mock("SOURCE_555", "VENDOR_777"),
+    ) as mock_get:
+        rv = client.get(f"/api/v1/payment-requests/{invoice.id}", headers=headers)
+
+    assert rv.status_code == 200
+
+    called_additional_headers = mock_get.call_args.kwargs.get("additional_headers")
+    assert called_additional_headers == {"Account-Linking-Key": "test-linking-key"}
+
+
+def test_get_invoice_linking_key_denied_for_non_business_invoice(session, client, jwt, app, linking_key_auth_mock):
+    """Assert a linking key does not grant access to a non-business-filing invoice."""
+    owner_account = factory_payment_account(auth_account_id="OWNER_999")
+    owner_account.save()
+    invoice = factory_invoice(payment_account=owner_account, business_identifier=None)
+    invoice.save()
+
+    token = jwt.create_jwt(get_claims(), token_header)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "content-type": "application/json",
+        "Account-Linking-Key": "test-linking-key",
+    }
+
+    with patch(
+        "pay_api.services.auth.RestService.get",
+        side_effect=linking_key_auth_mock("OWNER_999", "VENDOR_777", roles=[]),
+    ) as mock_get:
+        rv = client.get(f"/api/v1/payment-requests/{invoice.id}", headers=headers)
+
+    assert rv.status_code == 403
+
+    # No business identifier so the account id check should be used which does not use
+    # the account linking key
+    called_additional_headers = mock_get.call_args.kwargs.get("additional_headers")
+    assert not called_additional_headers or "Account-Linking-Key" not in called_additional_headers

--- a/pay-api/tests/unit/api/test_payment_request.py
+++ b/pay-api/tests/unit/api/test_payment_request.py
@@ -24,7 +24,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
-from flask import current_app
+from flask import abort, current_app
 from requests.exceptions import ConnectionError
 
 from pay_api.models import CorpType, FeeCode, FilingType
@@ -36,6 +36,7 @@ from pay_api.models import PaymentAccount as PaymentAccountModel
 from pay_api.models import RoutingSlip as RoutingSlipModel
 from pay_api.models.tax_rate import TaxRate
 from pay_api.schemas import utils as schema_utils
+from pay_api.utils.constants import ALL_ALLOWED_ROLES
 from pay_api.utils.enums import InvoiceStatus, PaymentMethod, Role, RoutingSlipStatus, TransactionStatus
 from tests.utilities.base_test import (
     activate_pad_account,
@@ -1960,7 +1961,14 @@ def test_payment_request_creation_account_id_ignores_linking_key(session, client
     assert payment_account.auth_account_id == source_account_id
 
 
-def test_get_invoice_linking_key_allows_business_filing_access(session, client, jwt, app, linking_key_auth_mock):
+def _authorize_via_linking_key_only(business_identifier, account_id=None, **kwargs):  # noqa: ARG001
+    """Mock check_auth: authorize only when called via the business-identifier/linking-key branch."""
+    if account_id is None:
+        return {"roles": ["edit", "view", "make_payment"]}
+    abort(403)
+
+
+def test_get_invoice_linking_key_allows_business_filing_access(session, client, jwt, app):
     """Assert a linking-key holder can fetch a business-filing invoice they don't directly own.
 
     _check_for_auth routes to check_auth without an account_id (business_identifier only) when a
@@ -1978,19 +1986,19 @@ def test_get_invoice_linking_key_allows_business_filing_access(session, client, 
         "Account-Linking-Key": "test-linking-key",
     }
 
-    with patch(
-        "pay_api.services.auth.RestService.get",
-        side_effect=linking_key_auth_mock("SOURCE_555", "VENDOR_777"),
-    ) as mock_get:
+    with patch("pay_api.services.invoice.check_auth", side_effect=_authorize_via_linking_key_only) as mock_check_auth:
         rv = client.get(f"/api/v1/payment-requests/{invoice.id}", headers=headers)
 
     assert rv.status_code == 200
 
-    called_additional_headers = mock_get.call_args.kwargs.get("additional_headers")
-    assert called_additional_headers == {"Account-Linking-Key": "test-linking-key"}
+    mock_check_auth.assert_called_once()
+    called_args, called_kwargs = mock_check_auth.call_args
+    assert called_args[0] == "CP0001234"  # business_identifier
+    assert called_kwargs.get("account_id") is None
+    assert called_kwargs.get("one_of_roles") == ALL_ALLOWED_ROLES
 
 
-def test_get_invoice_linking_key_denied_for_non_business_invoice(session, client, jwt, app, linking_key_auth_mock):
+def test_get_invoice_linking_key_denied_for_non_business_invoice(session, client, jwt, app):
     """Assert a linking key does not grant access to a non-business-filing invoice."""
     owner_account = factory_payment_account(auth_account_id="OWNER_999")
     owner_account.save()
@@ -2004,15 +2012,13 @@ def test_get_invoice_linking_key_denied_for_non_business_invoice(session, client
         "Account-Linking-Key": "test-linking-key",
     }
 
-    with patch(
-        "pay_api.services.auth.RestService.get",
-        side_effect=linking_key_auth_mock("OWNER_999", "VENDOR_777", roles=[]),
-    ) as mock_get:
+    with patch("pay_api.services.invoice.check_auth", side_effect=_authorize_via_linking_key_only) as mock_check_auth:
         rv = client.get(f"/api/v1/payment-requests/{invoice.id}", headers=headers)
 
     assert rv.status_code == 403
 
-    # No business identifier so the account id check should be used which does not use
-    # the account linking key
-    called_additional_headers = mock_get.call_args.kwargs.get("additional_headers")
-    assert not called_additional_headers or "Account-Linking-Key" not in called_additional_headers
+    mock_check_auth.assert_called_once()
+    called_args, called_kwargs = mock_check_auth.call_args
+    assert called_args[0] is None  # business_identifier
+    assert called_kwargs.get("account_id") == "OWNER_999"
+    assert called_kwargs.get("one_of_roles") == ALL_ALLOWED_ROLES

--- a/pay-api/tests/unit/api/test_receipt.py
+++ b/pay-api/tests/unit/api/test_receipt.py
@@ -19,6 +19,7 @@ Test-Suite to ensure that the /receipt endpoint is working as expected.
 
 import json
 from datetime import UTC, datetime
+from unittest.mock import patch
 
 import pytest
 
@@ -26,6 +27,8 @@ from pay_api.models import CfsAccount as CfsAccountModel
 from pay_api.models import PaymentAccount as PaymentAccountModel
 from pay_api.utils.enums import PaymentMethod, Role
 from tests.utilities.base_test import (
+    factory_invoice,
+    factory_payment_account,
     get_claims,
     get_payment_request,
     get_payment_request_with_no_contact_info,
@@ -297,3 +300,82 @@ def test_get_receipt(session, client, jwt, app):
 
     pay_receipt = client.get(f"/api/v1/payment-requests/{inovice_id}/receipts", headers=headers)
     assert pay_receipt.status_code == 200
+
+
+def test_post_receipt_linking_key_allows_business_filing_access(session, client, jwt, app, linking_key_auth_mock):
+    """Assert a linking-key can generate a receipt PDF for a business-filing invoice."""
+    vendor_account = factory_payment_account(auth_account_id="VENDOR_777")
+    vendor_account.save()
+    invoice = factory_invoice(
+        payment_account=vendor_account,
+        business_identifier="CP0001234",
+        payment_method_code=PaymentMethod.PAD.value,
+    )
+    invoice.save()
+
+    token = jwt.create_jwt(get_claims(), token_header)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "content-type": "application/json",
+        "Account-Linking-Key": "test-linking-key",
+    }
+    filing_data = {
+        "corpName": "CP0001234",
+        "filingDateTime": "June 27, 2019",
+        "fileName": "director-change",
+    }
+
+    with patch(
+        "pay_api.services.auth.RestService.get",
+        side_effect=linking_key_auth_mock("SOURCE_555", "VENDOR_777"),
+    ) as mock_get:
+        rv = client.post(
+            f"/api/v1/payment-requests/{invoice.id}/receipts",
+            data=json.dumps(filing_data),
+            headers=headers,
+        )
+
+    assert rv.status_code == 201
+    called_additional_headers = mock_get.call_args.kwargs.get("additional_headers")
+    assert called_additional_headers == {"Account-Linking-Key": "test-linking-key"}
+
+
+def test_post_receipt_linking_key_denied_for_non_business_invoice(session, client, jwt, app, linking_key_auth_mock):
+    """Assert a linking key does not grant access to generate a receipt for a non-business-filing invoice."""
+    owner_account = factory_payment_account(auth_account_id="OWNER_999")
+    owner_account.save()
+    invoice = factory_invoice(
+        payment_account=owner_account,
+        business_identifier=None,
+        payment_method_code=PaymentMethod.PAD.value,
+    )
+    invoice.save()
+
+    token = jwt.create_jwt(get_claims(), token_header)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "content-type": "application/json",
+        "Account-Linking-Key": "test-linking-key",
+    }
+    filing_data = {
+        "corpName": "CP0001234",
+        "filingDateTime": "June 27, 2019",
+        "fileName": "director-change",
+    }
+
+    with patch(
+        "pay_api.services.auth.RestService.get",
+        side_effect=linking_key_auth_mock("OWNER_999", "VENDOR_777", roles=[]),
+    ) as mock_get:
+        rv = client.post(
+            f"/api/v1/payment-requests/{invoice.id}/receipts",
+            data=json.dumps(filing_data),
+            headers=headers,
+        )
+
+    assert rv.status_code == 403
+
+    # No business identifier so the account id check should be used which does not use
+    # the account linking key
+    called_additional_headers = mock_get.call_args.kwargs.get("additional_headers")
+    assert not called_additional_headers or "Account-Linking-Key" not in called_additional_headers

--- a/pay-api/tests/unit/api/test_receipt.py
+++ b/pay-api/tests/unit/api/test_receipt.py
@@ -22,9 +22,11 @@ from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
+from flask import abort
 
 from pay_api.models import CfsAccount as CfsAccountModel
 from pay_api.models import PaymentAccount as PaymentAccountModel
+from pay_api.utils.constants import ALL_ALLOWED_ROLES
 from pay_api.utils.enums import PaymentMethod, Role
 from tests.utilities.base_test import (
     factory_invoice,
@@ -302,7 +304,14 @@ def test_get_receipt(session, client, jwt, app):
     assert pay_receipt.status_code == 200
 
 
-def test_post_receipt_linking_key_allows_business_filing_access(session, client, jwt, app, linking_key_auth_mock):
+def _authorize_via_linking_key_only(business_identifier, account_id=None, **kwargs):  # noqa: ARG001
+    """Mock check_auth: authorize only when called via the business-identifier/linking-key branch."""
+    if account_id is None:
+        return {"roles": ["edit", "view", "make_payment"]}
+    abort(403)
+
+
+def test_post_receipt_linking_key_allows_business_filing_access(session, client, jwt, app):
     """Assert a linking-key can generate a receipt PDF for a business-filing invoice."""
     vendor_account = factory_payment_account(auth_account_id="VENDOR_777")
     vendor_account.save()
@@ -325,10 +334,7 @@ def test_post_receipt_linking_key_allows_business_filing_access(session, client,
         "fileName": "director-change",
     }
 
-    with patch(
-        "pay_api.services.auth.RestService.get",
-        side_effect=linking_key_auth_mock("SOURCE_555", "VENDOR_777"),
-    ) as mock_get:
+    with patch("pay_api.services.invoice.check_auth", side_effect=_authorize_via_linking_key_only) as mock_check_auth:
         rv = client.post(
             f"/api/v1/payment-requests/{invoice.id}/receipts",
             data=json.dumps(filing_data),
@@ -336,11 +342,15 @@ def test_post_receipt_linking_key_allows_business_filing_access(session, client,
         )
 
     assert rv.status_code == 201
-    called_additional_headers = mock_get.call_args.kwargs.get("additional_headers")
-    assert called_additional_headers == {"Account-Linking-Key": "test-linking-key"}
+
+    mock_check_auth.assert_called_once()
+    called_args, called_kwargs = mock_check_auth.call_args
+    assert called_args[0] == "CP0001234"  # business_identifier
+    assert called_kwargs.get("account_id") is None
+    assert called_kwargs.get("one_of_roles") == ALL_ALLOWED_ROLES
 
 
-def test_post_receipt_linking_key_denied_for_non_business_invoice(session, client, jwt, app, linking_key_auth_mock):
+def test_post_receipt_linking_key_denied_for_non_business_invoice(session, client, jwt, app):
     """Assert a linking key does not grant access to generate a receipt for a non-business-filing invoice."""
     owner_account = factory_payment_account(auth_account_id="OWNER_999")
     owner_account.save()
@@ -363,10 +373,7 @@ def test_post_receipt_linking_key_denied_for_non_business_invoice(session, clien
         "fileName": "director-change",
     }
 
-    with patch(
-        "pay_api.services.auth.RestService.get",
-        side_effect=linking_key_auth_mock("OWNER_999", "VENDOR_777", roles=[]),
-    ) as mock_get:
+    with patch("pay_api.services.invoice.check_auth", side_effect=_authorize_via_linking_key_only) as mock_check_auth:
         rv = client.post(
             f"/api/v1/payment-requests/{invoice.id}/receipts",
             data=json.dumps(filing_data),
@@ -375,7 +382,8 @@ def test_post_receipt_linking_key_denied_for_non_business_invoice(session, clien
 
     assert rv.status_code == 403
 
-    # No business identifier so the account id check should be used which does not use
-    # the account linking key
-    called_additional_headers = mock_get.call_args.kwargs.get("additional_headers")
-    assert not called_additional_headers or "Account-Linking-Key" not in called_additional_headers
+    mock_check_auth.assert_called_once()
+    called_args, called_kwargs = mock_check_auth.call_args
+    assert called_args[0] is None  # business_identifier
+    assert called_kwargs.get("account_id") == "OWNER_999"
+    assert called_kwargs.get("one_of_roles") == ALL_ALLOWED_ROLES

--- a/pay-api/tests/unit/services/test_auth.py
+++ b/pay-api/tests/unit/services/test_auth.py
@@ -179,6 +179,17 @@ def test_check_auth_forwards_linking_key_for_business_identifier(
     with app.test_request_context(headers=headers):
         with patch("pay_api.services.auth.RestService.get") as mock_get:
             mock_get.return_value.json.return_value = {"roles": [EDIT_ROLE], "account": {"id": "1234"}}
-            check_auth("CP0001234", contains_role=EDIT_ROLE)
+            check_auth("CP0001234", contains_role=EDIT_ROLE, allow_linking_key=True)
 
         assert mock_get.call_args.kwargs["additional_headers"] == expected_additional_headers
+
+
+def test_check_auth_never_forwards_linking_key_without_explicit_opt_in(app, session, public_user_mock):
+    """Assert check_auth never forwards Account-Linking-Key when allow_linking_key is left at its default."""
+    headers = {"Account-Linking-Key": "some-linking-key"}
+    with app.test_request_context(headers=headers):
+        with patch("pay_api.services.auth.RestService.get") as mock_get:
+            mock_get.return_value.json.return_value = {"roles": [EDIT_ROLE], "account": {"id": "1234"}}
+            check_auth("CP0001234", account_id=None, contains_role=EDIT_ROLE)
+
+        assert mock_get.call_args.kwargs["additional_headers"] is None

--- a/pay-api/tests/unit/services/test_invoice.py
+++ b/pay-api/tests/unit/services/test_invoice.py
@@ -17,11 +17,14 @@
 Test-Suite to ensure that the FeeSchedule Service is working as expected.
 """
 
+from unittest.mock import patch
+
 import pytest
 
 from pay_api.exceptions import BusinessException
 from pay_api.models import FeeSchedule
 from pay_api.services.invoice import Invoice as Invoice_service
+from pay_api.utils.constants import ALL_ALLOWED_ROLES
 from pay_api.utils.enums import InvoiceStatus, PaymentMethod
 from tests.utilities.base_test import (
     factory_invoice,
@@ -128,3 +131,36 @@ def test_invoice_with_temproary_business_identifier(session):
     assert invoice.business_identifier is not None
     invoice_dict = invoice.asdict()
     assert invoice_dict.get("business_identifier") is None
+
+
+@pytest.mark.parametrize(
+    "allow_linking_key,has_linking_key,business_identifier,expected_account_id",
+    [
+        (True, True, "CP0001234", None),  # linking-key branch: no account_id
+        (False, True, "CP0001234", "VENDOR_777"),  # linking-key not allowed, use account id only
+        (True, True, None, "VENDOR_777"),  # no business_identifier - account id only
+        (True, False, "CP0001234", "VENDOR_777"),  # no linking key present - use account
+    ],
+)
+def test_check_for_auth_linking_key(
+    session, monkeypatch, allow_linking_key, has_linking_key, business_identifier, expected_account_id
+):
+    """Assert _check_for_auth only takes the linking-key/business-identifier branch when explicitly allowed."""
+    payment_account = factory_payment_account(auth_account_id="VENDOR_777")
+    payment_account.save()
+    invoice_dao = factory_invoice(payment_account=payment_account, business_identifier=business_identifier)
+    invoice_dao.save()
+
+    monkeypatch.setattr(
+        "pay_api.utils.user_context.get_account_linking_key",
+        lambda: "test-linking-key" if has_linking_key else None,
+    )
+
+    with patch("pay_api.services.invoice.check_auth", return_value={"roles": []}) as mock_check_auth:
+        Invoice_service._check_for_auth(invoice_dao, allow_linking_key=allow_linking_key)  # pylint: disable=protected-access
+
+    mock_check_auth.assert_called_once()
+    called_args, called_kwargs = mock_check_auth.call_args
+    assert called_args[0] == business_identifier
+    assert called_kwargs.get("account_id") == expected_account_id
+    assert called_kwargs.get("one_of_roles") == ALL_ALLOWED_ROLES

--- a/pay-api/tests/unit/services/test_payment_service.py
+++ b/pay-api/tests/unit/services/test_payment_service.py
@@ -33,6 +33,7 @@ from pay_api.services.internal_pay_service import InternalPayService
 from pay_api.services.payment_account import PaymentAccount as PaymentAccountService
 from pay_api.services.payment_line_item import PaymentLineItem
 from pay_api.services.payment_service import PaymentService
+from pay_api.utils.constants import ALL_ALLOWED_ROLES, EDIT_ROLE
 from pay_api.utils.enums import InvoiceStatus, PaymentMethod, PaymentStatus, RoutingSlipStatus
 from pay_api.utils.errors import Error
 from tests.utilities.base_test import (
@@ -536,3 +537,63 @@ def test_calculate_gst_invoice_versus_pli(session, public_user_mock):
                 line_item.total + line_item.service_fees + line_item.statutory_fees_gst + line_item.service_fees_gst
                 == expected_total
             )
+
+
+def test_patch_invoice_excludes_linking_key(session, public_user_mock, monkeypatch):
+    """Assert update_invoice (PATCH) never takes the linking-key/business-identifier auth branch."""
+    payment_account = factory_payment_account(
+        auth_account_id="VENDOR_777", payment_method_code=PaymentMethod.ONLINE_BANKING.value
+    )
+    payment_account.save()
+    invoice = factory_invoice(
+        payment_account=payment_account,
+        business_identifier="CP0001234",
+        payment_method_code=PaymentMethod.ONLINE_BANKING.value,
+    )
+    invoice.save()
+    factory_invoice_reference(invoice.id).save()
+
+    monkeypatch.setattr("pay_api.utils.user_context.get_account_linking_key", lambda: "test-linking-key")
+
+    with patch("pay_api.services.invoice.check_auth", return_value={"roles": [EDIT_ROLE]}) as mock_check_auth:
+        response = PaymentService.update_invoice(
+            invoice.id, {"paymentInfo": {"methodOfPayment": PaymentMethod.CC.value}}
+        )
+
+    assert response.get("payment_method") == PaymentMethod.CC.value
+
+    mock_check_auth.assert_called_once()
+    called_args, called_kwargs = mock_check_auth.call_args
+    assert called_args[0] == "CP0001234"
+    assert called_kwargs.get("account_id") == "VENDOR_777"
+    assert called_kwargs.get("one_of_roles") == ALL_ALLOWED_ROLES
+    assert called_kwargs.get("allow_linking_key") in (None, False)
+
+
+def test_accept_delete_excludes_linking_key(session, public_user_mock, monkeypatch):
+    """Assert accept_delete (DELETE) never takes the linking-key/business-identifier auth branch."""
+    payment_account = factory_payment_account(auth_account_id="VENDOR_777")
+    payment_account.save()
+    invoice = factory_invoice(
+        payment_account=payment_account,
+        business_identifier="CP0001234",
+        payment_method_code=PaymentMethod.PAD.value,
+    )
+    invoice.save()
+
+    monkeypatch.setattr("pay_api.utils.user_context.get_account_linking_key", lambda: "test-linking-key")
+
+    with (
+        patch("pay_api.services.payment_service.Thread") as mock_thread,
+        patch("pay_api.services.invoice.check_auth", return_value={"roles": [EDIT_ROLE]}) as mock_check_auth,
+    ):
+        PaymentService.accept_delete(invoice.id)
+
+    mock_thread.assert_called_once()
+
+    mock_check_auth.assert_called_once()
+    called_args, called_kwargs = mock_check_auth.call_args
+    assert called_args[0] == "CP0001234"
+    assert called_kwargs.get("account_id") == "VENDOR_777"
+    assert called_kwargs.get("one_of_roles") == [EDIT_ROLE]
+    assert called_kwargs.get("allow_linking_key") in (None, False)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/34417

- refactor account-linking-key logic to be opt-in for check auth to limit usage to specific operations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-pay license (Apache 2.0).
